### PR TITLE
Some cleanup

### DIFF
--- a/ev3dev/ev3dev.py
+++ b/ev3dev/ev3dev.py
@@ -1,4 +1,4 @@
-#------------------------------------------------------------------------------ 
+#------------------------------------------------------------------------------
 # Copyright (c) 2015 Ralph Hempel
 # Copyright (c) 2015 Anton Vanhoucke
 
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 # -----------------------------------------------------------------------------
 
-#~autogen autogen-header 
+#~autogen autogen-header
 # Sections of the following code were auto-generated based on spec v0.9.3-pre, rev 2
 
 #~autogen
@@ -30,7 +30,7 @@ import os.path
 import fnmatch
 import numbers
 
-#------------------------------------------------------------------------------ 
+#------------------------------------------------------------------------------
 # Define the base class from which all other ev3dev classes are defined.
 
 class Device(object):
@@ -41,17 +41,17 @@ class Device(object):
     def __init__(self, class_name, port='auto', name='*' ):
         """Spin through the Linux sysfs class for the device type and find
            the first unconnected device"""
-           
+
         self._classpath = os.path.abspath( Device.DEVICE_ROOT_PATH + '/' + class_name )
         self.filehandle_cache = {}
-        
+
         for file in os.listdir( self._classpath ):
             if 'auto' == port:
                 if fnmatch.fnmatch(file, name):
                     print 'Got a name match ' + file + ' <-> ' + name
                     self._path = os.path.abspath( self._classpath + '/' + file )
                     break
-            else:    
+            else:
                 port_name_file = os.path.abspath( self._classpath + '/' + file + '/port_name')
                 f = open( port_name_file, 'r' )
                 port_name = f.read().strip()
@@ -67,7 +67,7 @@ class Device(object):
         for f in self.filehandle_cache:
             print f
             f.close()
-            
+
     def __attribute_file( self, attribute, sys_attribute, mode, reopen=False ):
         """Manages the file handle cache and opening the files in the correct mode"""
 
@@ -106,7 +106,7 @@ class Device(object):
             f = self.__attribute_file( attribute, sys_attribute, 'w+', True )
             f.write( value )
             f.flush()
-        
+
     def _get_int_attribute( self, attribute, sys_attribute ):
         return int( self._get_attribute( attribute, sys_attribute ) )
 
@@ -117,7 +117,7 @@ class Device(object):
             self._set_attribute( attribute, sys_attribute, '{0:.0f}'.format( value ) )
         elif True == isinstance( value, str ):
             self._set_attribute( attribute, sys_attribute, value )
-        
+
     def _get_string_attribute( self, attribute, sys_attribute ):
         return self._get_attribute( attribute, sys_attribute )
 
@@ -144,7 +144,7 @@ class Device(object):
 
 #~autogen python_generic-class classes.motor>currentClass
 
- 
+
 class Motor(Device):
 
     """
@@ -497,36 +497,36 @@ class Motor(Device):
 #~autogen python_generic-property-value classes.motor>currentClass
 
 
-    __propval_command = {  
-      'run-forever':'Run the motor until another command is sent.' , 
-      'run-to-abs-pos':'Run to an absolute position specified by `position_sp` and thenstop using the command specified in `stop_command`.' , 
-      'run-to-rel-pos':'Run to a position relative to the current `position` value.The new position will be current `position` + `position_sp`.When the new position is reached, the motor will stop usingthe command specified by `stop_command`.' , 
-      'run-timed':'Run the motor for the amount of time specified in `time_sp`and then stop the motor using the command specified by `stop_command`.' , 
-      'run-direct':'Run the motor at the duty cycle specified by `duty_cycle_sp`.Unlike other run commands, changing `duty_cycle_sp` while running *will*take effect immediately.' , 
-      'stop':'Stop any of the run commands before they are complete using thecommand specified by `stop_command`.' , 
+    __propval_command = {
+      'run-forever':'Run the motor until another command is sent.' ,
+      'run-to-abs-pos':'Run to an absolute position specified by `position_sp` and thenstop using the command specified in `stop_command`.' ,
+      'run-to-rel-pos':'Run to a position relative to the current `position` value.The new position will be current `position` + `position_sp`.When the new position is reached, the motor will stop usingthe command specified by `stop_command`.' ,
+      'run-timed':'Run the motor for the amount of time specified in `time_sp`and then stop the motor using the command specified by `stop_command`.' ,
+      'run-direct':'Run the motor at the duty cycle specified by `duty_cycle_sp`.Unlike other run commands, changing `duty_cycle_sp` while running *will*take effect immediately.' ,
+      'stop':'Stop any of the run commands before they are complete using thecommand specified by `stop_command`.' ,
       'reset':'Reset all of the motor parameter attributes to their default value.This will also have the effect of stopping the motor.' ,
-          }
+      }
 
-    __propval_encoder_polarity = {  
-      'normal':'Sets the normal polarity of the rotary encoder.' , 
+    __propval_encoder_polarity = {
+      'normal':'Sets the normal polarity of the rotary encoder.' ,
       'inversed':'Sets the inversed polarity of the rotary encoder.' ,
-          }
+      }
 
-    __propval_polarity = {  
-      'normal':'With `normal` polarity, a positive duty cycle willcause the motor to rotate clockwise.' , 
+    __propval_polarity = {
+      'normal':'With `normal` polarity, a positive duty cycle willcause the motor to rotate clockwise.' ,
       'inversed':'With `inversed` polarity, a positive duty cycle willcause the motor to rotate counter-clockwise.' ,
-          }
+      }
 
-    __propval_speed_regulation = {  
-      'on':'The motor controller will vary the power supplied to the motorto try to maintain the speed specified in `speed_sp`.' , 
+    __propval_speed_regulation = {
+      'on':'The motor controller will vary the power supplied to the motorto try to maintain the speed specified in `speed_sp`.' ,
       'off':'The motor controller will use the power specified in `duty_cycle_sp`.' ,
-          }
+      }
 
-    __propval_stop_command = {  
-      'coast':'Power will be removed from the motor and it will freely coast to a stop.' , 
-      'brake':'Power will be removed from the motor and a passive electrical load willbe placed on the motor. This is usually done by shorting the motor terminalstogether. This load will absorb the energy from the rotation of the motors andcause the motor to stop more quickly than coasting.' , 
+    __propval_stop_command = {
+      'coast':'Power will be removed from the motor and it will freely coast to a stop.' ,
+      'brake':'Power will be removed from the motor and a passive electrical load willbe placed on the motor. This is usually done by shorting the motor terminalstogether. This load will absorb the energy from the rotation of the motors andcause the motor to stop more quickly than coasting.' ,
       'hold':'Does not remove power from the motor. Instead it actively try to hold the motorat the current position. If an external force tries to turn the motor, the motorwill ``push back`` to maintain its position.' ,
-          }
+      }
 
 #~autogen
 #~autogen python_generic-helper-function classes.motor>currentClass
@@ -550,7 +550,7 @@ class Motor(Device):
 	    , 'speed_regulation_d' : __set_speed_regulation_d
 	    , 'stop_command' : __set_stop_command
 	    , 'time_sp' : __set_time_sp }
-    
+
     def _helper( self, **kwargs ):
         for p,v in kwargs.iteritems():
             if p in self._properties:
@@ -588,7 +588,7 @@ class Motor(Device):
 #~autogen
 #~autogen python_generic-class classes.dcMotor>currentClass
 
- 
+
 class DcMotor(Device):
 
     """
@@ -747,22 +747,22 @@ class DcMotor(Device):
 #~autogen python_generic-property-value classes.dcMotor>currentClass
 
 
-    __propval_command = {  
-      'run-forever':'Run the motor until another command is sent.' , 
-      'run-timed':'Run the motor for the amount of time specified in `time_sp`and then stop the motor using the command specified by `stop_command`.' , 
-      'run-direct':'Run the motor at the duty cycle specified by `duty_cycle_sp`.Unlike other run commands, changing `duty_cycle_sp` while running *will*take effect immediately.' , 
+    __propval_command = {
+      'run-forever':'Run the motor until another command is sent.' ,
+      'run-timed':'Run the motor for the amount of time specified in `time_sp`and then stop the motor using the command specified by `stop_command`.' ,
+      'run-direct':'Run the motor at the duty cycle specified by `duty_cycle_sp`.Unlike other run commands, changing `duty_cycle_sp` while running *will*take effect immediately.' ,
       'stop':'Stop any of the run commands before they are complete using thecommand specified by `stop_command`.' ,
-          }
+      }
 
-    __propval_polarity = {  
-      'normal':'With `normal` polarity, a positive duty cycle willcause the motor to rotate clockwise.' , 
+    __propval_polarity = {
+      'normal':'With `normal` polarity, a positive duty cycle willcause the motor to rotate clockwise.' ,
       'inversed':'With `inversed` polarity, a positive duty cycle willcause the motor to rotate counter-clockwise.' ,
-          }
+      }
 
-    __propval_stop_command = {  
-      'coast':'Power will be removed from the motor and it will freely coast to a stop.' , 
+    __propval_stop_command = {
+      'coast':'Power will be removed from the motor and it will freely coast to a stop.' ,
       'brake':'Power will be removed from the motor and a passive electrical load willbe placed on the motor. This is usually done by shorting the motor terminalstogether. This load will absorb the energy from the rotation of the motors andcause the motor to stop more quickly than coasting.' ,
-          }
+      }
 
 #~autogen
 
@@ -776,7 +776,7 @@ class DcMotor(Device):
 	    , 'ramp_up_sp' : __set_ramp_up_sp
 	    , 'stop_command' : __set_stop_command
 	    , 'time_sp' : __set_time_sp }
-    
+
     def _helper( self, **kwargs ):
         for p,v in kwargs.iteritems():
             if p in self._properties:
@@ -803,7 +803,7 @@ class DcMotor(Device):
 
 #~autogen python_generic-class classes.servoMotor>currentClass
 
- 
+
 class ServoMotor(Device):
 
     """
@@ -951,15 +951,15 @@ class ServoMotor(Device):
 #~autogen python_generic-property-value classes.servoMotor>currentClass
 
 
-    __propval_command = {  
-      'run':'Drive servo to the position set in the `position_sp` attribute.' , 
+    __propval_command = {
+      'run':'Drive servo to the position set in the `position_sp` attribute.' ,
       'float':'Remove power from the motor.' ,
-          }
+      }
 
-    __propval_polarity = {  
-      'normal':'With `normal` polarity, a positive duty cycle willcause the motor to rotate clockwise.' , 
+    __propval_polarity = {
+      'normal':'With `normal` polarity, a positive duty cycle willcause the motor to rotate clockwise.' ,
       'inversed':'With `inversed` polarity, a positive duty cycle willcause the motor to rotate counter-clockwise.' ,
-          }
+      }
 
 #~autogen
 
@@ -973,7 +973,7 @@ class ServoMotor(Device):
 	    , 'polarity' : __set_polarity
 	    , 'position_sp' : __set_position_sp
 	    , 'rate_sp' : __set_rate_sp }
-    
+
     def _helper( self, **kwargs ):
         for p,v in kwargs.iteritems():
             if p in self._properties:
@@ -992,7 +992,7 @@ class ServoMotor(Device):
 
 #~autogen python_generic-class classes.sensor>currentClass
 
- 
+
 class Sensor(Device):
 
     """
@@ -1120,7 +1120,7 @@ class Sensor(Device):
 
 #~autogen python_generic-class classes.i2cSensor>currentClass
 
- 
+
 class I2cSensor(Device):
 
     """
@@ -1164,7 +1164,7 @@ class I2cSensor(Device):
 #~autogen
 #~autogen python_generic-class classes.colorSensor>currentClass
 
- 
+
 class ColorSensor(Device):
 
     """
@@ -1181,18 +1181,18 @@ class ColorSensor(Device):
 #~autogen python_generic-property-value classes.colorSensor>currentClass
 
 
-    __propval_mode = {  
-      'COL-REFLECT':'Reflected light. Red LED on.' , 
-      'COL-AMBIENT':'Ambient light. Red LEDs off.' , 
-      'COL-COLOR':'Color. All LEDs rapidly cycling, appears white.' , 
-      'REF-RAW':'Raw reflected. Red LED on' , 
+    __propval_mode = {
+      'COL-REFLECT':'Reflected light. Red LED on.' ,
+      'COL-AMBIENT':'Ambient light. Red LEDs off.' ,
+      'COL-COLOR':'Color. All LEDs rapidly cycling, appears white.' ,
+      'REF-RAW':'Raw reflected. Red LED on' ,
       'RGB-RAW':'Raw Color Components. All LEDs rapidly cycling, appears white.' ,
-          }
+      }
 
 #~autogen
 #~autogen python_generic-class classes.ultrasonicSensor>currentClass
 
- 
+
 class UltrasonicSensor(Device):
 
     """
@@ -1209,18 +1209,18 @@ class UltrasonicSensor(Device):
 #~autogen python_generic-property-value classes.ultrasonicSensor>currentClass
 
 
-    __propval_mode = {  
-      'US-DIST-CM':'Continuous measurement in centimeters.LEDs: On, steady' , 
-      'US-DIST-IN':'Continuous measurement in inches.LEDs: On, steady' , 
-      'US-LISTEN':'Listen.  LEDs: On, blinking' , 
-      'US-SI-CM':'Single measurement in centimeters.LEDs: On momentarily when mode is set, then off' , 
+    __propval_mode = {
+      'US-DIST-CM':'Continuous measurement in centimeters.LEDs: On, steady' ,
+      'US-DIST-IN':'Continuous measurement in inches.LEDs: On, steady' ,
+      'US-LISTEN':'Listen.  LEDs: On, blinking' ,
+      'US-SI-CM':'Single measurement in centimeters.LEDs: On momentarily when mode is set, then off' ,
       'US-SI-IN':'Single measurement in inches.LEDs: On momentarily when mode is set, then off' ,
-          }
+      }
 
 #~autogen
 #~autogen python_generic-class classes.gyroSensor>currentClass
 
- 
+
 class GyroSensor(Device):
 
     """
@@ -1237,18 +1237,18 @@ class GyroSensor(Device):
 #~autogen python_generic-property-value classes.gyroSensor>currentClass
 
 
-    __propval_mode = {  
-      'GYRO-ANG':'Angle' , 
-      'GYRO-RATE':'Rotational speed' , 
-      'GYRO-FAS':'Raw sensor value' , 
-      'GYRO-G&A':'Angle and rotational speed' , 
+    __propval_mode = {
+      'GYRO-ANG':'Angle' ,
+      'GYRO-RATE':'Rotational speed' ,
+      'GYRO-FAS':'Raw sensor value' ,
+      'GYRO-G&A':'Angle and rotational speed' ,
       'GYRO-CAL':'Calibration ???' ,
-          }
+      }
 
 #~autogen
 #~autogen python_generic-class classes.infraredSensor>currentClass
 
- 
+
 class InfraredSensor(Device):
 
     """
@@ -1265,20 +1265,20 @@ class InfraredSensor(Device):
 #~autogen python_generic-property-value classes.infraredSensor>currentClass
 
 
-    __propval_mode = {  
-      'IR-PROX':'Proximity' , 
-      'IR-SEEK':'IR Seeker' , 
-      'IR-REMOTE':'IR Remote Control' , 
-      'IR-REM-A':'IR Remote Control. State of the buttons is coded in binary' , 
+    __propval_mode = {
+      'IR-PROX':'Proximity' ,
+      'IR-SEEK':'IR Seeker' ,
+      'IR-REMOTE':'IR Remote Control' ,
+      'IR-REM-A':'IR Remote Control. State of the buttons is coded in binary' ,
       'IR-CAL':'Calibration ???' ,
-          }
+      }
 
 #~autogen
 
- 
+
 #~autogen python_generic-class classes.soundSensor>currentClass
 
- 
+
 class SoundSensor(Device):
 
     """
@@ -1295,15 +1295,15 @@ class SoundSensor(Device):
 #~autogen python_generic-property-value classes.soundSensor>currentClass
 
 
-    __propval_mode = {  
-      'DB':'Sound pressure level. Flat weighting' , 
+    __propval_mode = {
+      'DB':'Sound pressure level. Flat weighting' ,
       'DBA':'Sound pressure level. A weighting' ,
-          }
+      }
 
 #~autogen
 #~autogen python_generic-class classes.lightSensor>currentClass
 
- 
+
 class LightSensor(Device):
 
     """
@@ -1320,15 +1320,15 @@ class LightSensor(Device):
 #~autogen python_generic-property-value classes.lightSensor>currentClass
 
 
-    __propval_mode = {  
-      'REFLECT':'Reflected light. LED on' , 
+    __propval_mode = {
+      'REFLECT':'Reflected light. LED on' ,
       'AMBIENT':'Ambient light. LED off' ,
-          }
+      }
 
 #~autogen
 #~autogen python_generic-class classes.led>currentClass
 
- 
+
 class Led(Device):
 
     """
@@ -1428,7 +1428,7 @@ class Led(Device):
 #~autogen
 #~autogen python_generic-class classes.powerSupply>currentClass
 
- 
+
 class PowerSupply(Device):
 
     """
@@ -1494,7 +1494,7 @@ class PowerSupply(Device):
 #~autogen
 #~autogen python_generic-class classes.legoPort>currentClass
 
- 
+
 class LegoPort(Device):
 
     """

--- a/ev3dev/ev3dev.py
+++ b/ev3dev/ev3dev.py
@@ -167,62 +167,67 @@ class Motor(Device):
     def __set_command(self, value):
         self._set_string_attribute( 'command', 'command', value )
 
-    __doc_command = (
-        "Sends a command to the motor controller. See `commands` for a list of\n"
-        "possible values.\n"        )
+    __doc_command = """
+        Sends a command to the motor controller. See `commands` for a list of
+        possible values.
+        """
 
     command = property( None, __set_command, None, __doc_command )
 
     def __get_commands(self):
         return self._get_string_array_attribute( 'commands', 'commands' )
 
-    __doc_commands = (
-        "Returns a list of commands that are supported by the motor\n"
-        "controller. Possible values are `run-forever`, `run-to-abs-pos`, `run-to-rel-pos`,\n"
-        "`run-timed`, `run-direct`, `stop` and `reset`. Not all commands may be supported.\n"
-        "`run-forever` will cause the motor to run until another command is sent.\n"
-        "`run-to-abs-pos` will run to an absolute position specified by `position_sp`\n"
-        "and then stop using the command specified in `stop_command`.\n"
-        "`run-to-rel-pos` will run to a position relative to the current `position` value.\n"
-        "The new position will be current `position` + `position_sp`. When the new\n"
-        "position is reached, the motor will stop using the command specified by `stop_command`.\n"
-        "`run-timed` will run the motor for the amount of time specified in `time_sp`\n"
-        "and then stop the motor using the command specified by `stop_command`.\n"
-        "`run-direct` will run the motor at the duty cycle specified by `duty_cycle_sp`.\n"
-        "Unlike other run commands, changing `duty_cycle_sp` while running *will*\n"
-        "take effect immediately.\n"
-        "`stop` will stop any of the run commands before they are complete using the\n"
-        "command specified by `stop_command`.\n"
-        "`reset` will reset all of the motor parameter attributes to their default value.\n"
-        "This will also have the effect of stopping the motor.\n"        )
+    __doc_commands = """
+        Returns a list of commands that are supported by the motor
+        controller. Possible values are `run-forever`, `run-to-abs-pos`, `run-to-rel-pos`,
+        `run-timed`, `run-direct`, `stop` and `reset`. Not all commands may be supported.
+        `run-forever` will cause the motor to run until another command is sent.
+        `run-to-abs-pos` will run to an absolute position specified by `position_sp`
+        and then stop using the command specified in `stop_command`.
+        `run-to-rel-pos` will run to a position relative to the current `position` value.
+        The new position will be current `position` + `position_sp`. When the new
+        position is reached, the motor will stop using the command specified by `stop_command`.
+        `run-timed` will run the motor for the amount of time specified in `time_sp`
+        and then stop the motor using the command specified by `stop_command`.
+        `run-direct` will run the motor at the duty cycle specified by `duty_cycle_sp`.
+        Unlike other run commands, changing `duty_cycle_sp` while running *will*
+        take effect immediately.
+        `stop` will stop any of the run commands before they are complete using the
+        command specified by `stop_command`.
+        `reset` will reset all of the motor parameter attributes to their default value.
+        This will also have the effect of stopping the motor.
+        """
 
     commands = property( __get_commands, None, None, __doc_commands )
 
     def __get_count_per_rot(self):
         return self._get_int_attribute( 'count_per_rot', 'count_per_rot' )
 
-    __doc_count_per_rot = (
-        "Returns the number of tacho counts in one rotation of the motor. Tacho counts\n"
-        "are used by the position and speed attributes, so you can use this value\n"
-        "to convert rotations or degrees to tacho counts. In the case of linear\n"
-        "actuators, the units here will be counts per centimeter.\n"        )
+    __doc_count_per_rot = """
+        Returns the number of tacho counts in one rotation of the motor. Tacho counts
+        are used by the position and speed attributes, so you can use this value
+        to convert rotations or degrees to tacho counts. In the case of linear
+        actuators, the units here will be counts per centimeter.
+        """
 
     count_per_rot = property( __get_count_per_rot, None, None, __doc_count_per_rot )
 
     def __get_driver_name(self):
         return self._get_string_attribute( 'driver_name', 'driver_name' )
 
-    __doc_driver_name = (
-        "Returns the name of the driver that provides this tacho motor device.\n"        )
+    __doc_driver_name = """
+        Returns the name of the driver that provides this tacho motor device.
+        """
 
     driver_name = property( __get_driver_name, None, None, __doc_driver_name )
 
     def __get_duty_cycle(self):
         return self._get_int_attribute( 'duty_cycle', 'duty_cycle' )
 
-    __doc_duty_cycle = (
-        "Returns the current duty cycle of the motor. Units are percent. Values\n"
-        "are -100 to 100.\n"        )
+    __doc_duty_cycle = """
+        Returns the current duty cycle of the motor. Units are percent. Values
+        are -100 to 100.
+        """
 
     duty_cycle = property( __get_duty_cycle, None, None, __doc_duty_cycle )
 
@@ -232,11 +237,12 @@ class Motor(Device):
     def __set_duty_cycle_sp(self, value):
         self._set_int_attribute( 'duty_cycle_sp', 'duty_cycle_sp', value )
 
-    __doc_duty_cycle_sp = (
-        "Writing sets the duty cycle setpoint. Reading returns the current value.\n"
-        "Units are in percent. Valid values are -100 to 100. A negative value causes\n"
-        "the motor to rotate in reverse. This value is only used when `speed_regulation`\n"
-        "is off.\n"        )
+    __doc_duty_cycle_sp = """
+        Writing sets the duty cycle setpoint. Reading returns the current value.
+        Units are in percent. Valid values are -100 to 100. A negative value causes
+        the motor to rotate in reverse. This value is only used when `speed_regulation`
+        is off.
+        """
 
     duty_cycle_sp = property( __get_duty_cycle_sp, __set_duty_cycle_sp, None, __doc_duty_cycle_sp )
 
@@ -246,12 +252,13 @@ class Motor(Device):
     def __set_encoder_polarity(self, value):
         self._set_string_attribute( 'encoder_polarity', 'encoder_polarity', value )
 
-    __doc_encoder_polarity = (
-        "Sets the polarity of the rotary encoder. This is an advanced feature to all\n"
-        "use of motors that send inversed encoder signals to the EV3. This should\n"
-        "be set correctly by the driver of a device. It You only need to change this\n"
-        "value if you are using a unsupported device. Valid values are `normal` and\n"
-        "`inversed`.\n"        )
+    __doc_encoder_polarity = """
+        Sets the polarity of the rotary encoder. This is an advanced feature to all
+        use of motors that send inversed encoder signals to the EV3. This should
+        be set correctly by the driver of a device. It You only need to change this
+        value if you are using a unsupported device. Valid values are `normal` and
+        `inversed`.
+        """
 
     encoder_polarity = property( __get_encoder_polarity, __set_encoder_polarity, None, __doc_encoder_polarity )
 
@@ -261,19 +268,21 @@ class Motor(Device):
     def __set_polarity(self, value):
         self._set_string_attribute( 'polarity', 'polarity', value )
 
-    __doc_polarity = (
-        "Sets the polarity of the motor. With `normal` polarity, a positive duty\n"
-        "cycle will cause the motor to rotate clockwise. With `inversed` polarity,\n"
-        "a positive duty cycle will cause the motor to rotate counter-clockwise.\n"
-        "Valid values are `normal` and `inversed`.\n"        )
+    __doc_polarity = """
+        Sets the polarity of the motor. With `normal` polarity, a positive duty
+        cycle will cause the motor to rotate clockwise. With `inversed` polarity,
+        a positive duty cycle will cause the motor to rotate counter-clockwise.
+        Valid values are `normal` and `inversed`.
+        """
 
     polarity = property( __get_polarity, __set_polarity, None, __doc_polarity )
 
     def __get_port_name(self):
         return self._get_string_attribute( 'port_name', 'port_name' )
 
-    __doc_port_name = (
-        "Returns the name of the port that the motor is connected to.\n"        )
+    __doc_port_name = """
+        Returns the name of the port that the motor is connected to.
+        """
 
     port_name = property( __get_port_name, None, None, __doc_port_name )
 
@@ -283,11 +292,12 @@ class Motor(Device):
     def __set_position(self, value):
         self._set_int_attribute( 'position', 'position', value )
 
-    __doc_position = (
-        "Returns the current position of the motor in pulses of the rotary\n"
-        "encoder. When the motor rotates clockwise, the position will increase.\n"
-        "Likewise, rotating counter-clockwise causes the position to decrease.\n"
-        "Writing will set the position to that value.\n"        )
+    __doc_position = """
+        Returns the current position of the motor in pulses of the rotary
+        encoder. When the motor rotates clockwise, the position will increase.
+        Likewise, rotating counter-clockwise causes the position to decrease.
+        Writing will set the position to that value.
+        """
 
     position = property( __get_position, __set_position, None, __doc_position )
 
@@ -297,8 +307,9 @@ class Motor(Device):
     def __set_position_p(self, value):
         self._set_int_attribute( 'position_p', 'hold_pid/Kp', value )
 
-    __doc_position_p = (
-        "The proportional constant for the position PID.\n"        )
+    __doc_position_p = """
+        The proportional constant for the position PID.
+        """
 
     position_p = property( __get_position_p, __set_position_p, None, __doc_position_p )
 
@@ -308,8 +319,9 @@ class Motor(Device):
     def __set_position_i(self, value):
         self._set_int_attribute( 'position_i', 'hold_pid/Ki', value )
 
-    __doc_position_i = (
-        "The integral constant for the position PID.\n"        )
+    __doc_position_i = """
+        The integral constant for the position PID.
+        """
 
     position_i = property( __get_position_i, __set_position_i, None, __doc_position_i )
 
@@ -319,8 +331,9 @@ class Motor(Device):
     def __set_position_d(self, value):
         self._set_int_attribute( 'position_d', 'hold_pid/Kd', value )
 
-    __doc_position_d = (
-        "The derivative constant for the position PID.\n"        )
+    __doc_position_d = """
+        The derivative constant for the position PID.
+        """
 
     position_d = property( __get_position_d, __set_position_d, None, __doc_position_d )
 
@@ -330,21 +343,23 @@ class Motor(Device):
     def __set_position_sp(self, value):
         self._set_int_attribute( 'position_sp', 'position_sp', value )
 
-    __doc_position_sp = (
-        "Writing specifies the target position for the `run-to-abs-pos` and `run-to-rel-pos`\n"
-        "commands. Reading returns the current value. Units are in tacho counts. You\n"
-        "can use the value returned by `counts_per_rot` to convert tacho counts to/from\n"
-        "rotations or degrees.\n"        )
+    __doc_position_sp = """
+        Writing specifies the target position for the `run-to-abs-pos` and `run-to-rel-pos`
+        commands. Reading returns the current value. Units are in tacho counts. You
+        can use the value returned by `counts_per_rot` to convert tacho counts to/from
+        rotations or degrees.
+        """
 
     position_sp = property( __get_position_sp, __set_position_sp, None, __doc_position_sp )
 
     def __get_speed(self):
         return self._get_int_attribute( 'speed', 'speed' )
 
-    __doc_speed = (
-        "Returns the current motor speed in tacho counts per second. Not, this is\n"
-        "not necessarily degrees (although it is for LEGO motors). Use the `count_per_rot`\n"
-        "attribute to convert this value to RPM or deg/sec.\n"        )
+    __doc_speed = """
+        Returns the current motor speed in tacho counts per second. Not, this is
+        not necessarily degrees (although it is for LEGO motors). Use the `count_per_rot`
+        attribute to convert this value to RPM or deg/sec.
+        """
 
     speed = property( __get_speed, None, None, __doc_speed )
 
@@ -354,10 +369,11 @@ class Motor(Device):
     def __set_speed_sp(self, value):
         self._set_int_attribute( 'speed_sp', 'speed_sp', value )
 
-    __doc_speed_sp = (
-        "Writing sets the target speed in tacho counts per second used when `speed_regulation`\n"
-        "is on. Reading returns the current value.  Use the `count_per_rot` attribute\n"
-        "to convert RPM or deg/sec to tacho counts per second.\n"        )
+    __doc_speed_sp = """
+        Writing sets the target speed in tacho counts per second used when `speed_regulation`
+        is on. Reading returns the current value.  Use the `count_per_rot` attribute
+        to convert RPM or deg/sec to tacho counts per second.
+        """
 
     speed_sp = property( __get_speed_sp, __set_speed_sp, None, __doc_speed_sp )
 
@@ -367,12 +383,13 @@ class Motor(Device):
     def __set_ramp_up_sp(self, value):
         self._set_int_attribute( 'ramp_up_sp', 'ramp_up_sp', value )
 
-    __doc_ramp_up_sp = (
-        "Writing sets the ramp up setpoint. Reading returns the current value. Units\n"
-        "are in milliseconds. When set to a value > 0, the motor will ramp the power\n"
-        "sent to the motor from 0 to 100% duty cycle over the span of this setpoint\n"
-        "when starting the motor. If the maximum duty cycle is limited by `duty_cycle_sp`\n"
-        "or speed regulation, the actual ramp time duration will be less than the setpoint.\n"        )
+    __doc_ramp_up_sp = """
+        Writing sets the ramp up setpoint. Reading returns the current value. Units
+        are in milliseconds. When set to a value > 0, the motor will ramp the power
+        sent to the motor from 0 to 100% duty cycle over the span of this setpoint
+        when starting the motor. If the maximum duty cycle is limited by `duty_cycle_sp`
+        or speed regulation, the actual ramp time duration will be less than the setpoint.
+        """
 
     ramp_up_sp = property( __get_ramp_up_sp, __set_ramp_up_sp, None, __doc_ramp_up_sp )
 
@@ -382,12 +399,13 @@ class Motor(Device):
     def __set_ramp_down_sp(self, value):
         self._set_int_attribute( 'ramp_down_sp', 'ramp_down_sp', value )
 
-    __doc_ramp_down_sp = (
-        "Writing sets the ramp down setpoint. Reading returns the current value. Units\n"
-        "are in milliseconds. When set to a value > 0, the motor will ramp the power\n"
-        "sent to the motor from 100% duty cycle down to 0 over the span of this setpoint\n"
-        "when stopping the motor. If the starting duty cycle is less than 100%, the\n"
-        "ramp time duration will be less than the full span of the setpoint.\n"        )
+    __doc_ramp_down_sp = """
+        Writing sets the ramp down setpoint. Reading returns the current value. Units
+        are in milliseconds. When set to a value > 0, the motor will ramp the power
+        sent to the motor from 100% duty cycle down to 0 over the span of this setpoint
+        when stopping the motor. If the starting duty cycle is less than 100%, the
+        ramp time duration will be less than the full span of the setpoint.
+        """
 
     ramp_down_sp = property( __get_ramp_down_sp, __set_ramp_down_sp, None, __doc_ramp_down_sp )
 
@@ -397,12 +415,13 @@ class Motor(Device):
     def __set_speed_regulation_enabled(self, value):
         self._set_string_attribute( 'speed_regulation_enabled', 'speed_regulation', value )
 
-    __doc_speed_regulation_enabled = (
-        "Turns speed regulation on or off. If speed regulation is on, the motor\n"
-        "controller will vary the power supplied to the motor to try to maintain the\n"
-        "speed specified in `speed_sp`. If speed regulation is off, the controller\n"
-        "will use the power specified in `duty_cycle_sp`. Valid values are `on` and\n"
-        "`off`.\n"        )
+    __doc_speed_regulation_enabled = """
+        Turns speed regulation on or off. If speed regulation is on, the motor
+        controller will vary the power supplied to the motor to try to maintain the
+        speed specified in `speed_sp`. If speed regulation is off, the controller
+        will use the power specified in `duty_cycle_sp`. Valid values are `on` and
+        `off`.
+        """
 
     speed_regulation_enabled = property( __get_speed_regulation_enabled, __set_speed_regulation_enabled, None, __doc_speed_regulation_enabled )
 
@@ -412,8 +431,9 @@ class Motor(Device):
     def __set_speed_regulation_p(self, value):
         self._set_int_attribute( 'speed_regulation_p', 'speed_pid/Kp', value )
 
-    __doc_speed_regulation_p = (
-        "The proportional constant for the speed regulation PID.\n"        )
+    __doc_speed_regulation_p = """
+        The proportional constant for the speed regulation PID.
+        """
 
     speed_regulation_p = property( __get_speed_regulation_p, __set_speed_regulation_p, None, __doc_speed_regulation_p )
 
@@ -423,8 +443,9 @@ class Motor(Device):
     def __set_speed_regulation_i(self, value):
         self._set_int_attribute( 'speed_regulation_i', 'speed_pid/Ki', value )
 
-    __doc_speed_regulation_i = (
-        "The integral constant for the speed regulation PID.\n"        )
+    __doc_speed_regulation_i = """
+        The integral constant for the speed regulation PID.
+        """
 
     speed_regulation_i = property( __get_speed_regulation_i, __set_speed_regulation_i, None, __doc_speed_regulation_i )
 
@@ -434,17 +455,19 @@ class Motor(Device):
     def __set_speed_regulation_d(self, value):
         self._set_int_attribute( 'speed_regulation_d', 'speed_pid/Kd', value )
 
-    __doc_speed_regulation_d = (
-        "The derivative constant for the speed regulation PID.\n"        )
+    __doc_speed_regulation_d = """
+        The derivative constant for the speed regulation PID.
+        """
 
     speed_regulation_d = property( __get_speed_regulation_d, __set_speed_regulation_d, None, __doc_speed_regulation_d )
 
     def __get_state(self):
         return self._get_string_array_attribute( 'state', 'state' )
 
-    __doc_state = (
-        "Reading returns a list of state flags. Possible flags are\n"
-        "`running`, `ramping` `holding` and `stalled`.\n"        )
+    __doc_state = """
+        Reading returns a list of state flags. Possible flags are
+        `running`, `ramping` `holding` and `stalled`.
+        """
 
     state = property( __get_state, None, None, __doc_state )
 
@@ -454,28 +477,30 @@ class Motor(Device):
     def __set_stop_command(self, value):
         self._set_string_attribute( 'stop_command', 'stop_command', value )
 
-    __doc_stop_command = (
-        "Reading returns the current stop command. Writing sets the stop command.\n"
-        "The value determines the motors behavior when `command` is set to `stop`.\n"
-        "Also, it determines the motors behavior when a run command completes. See\n"
-        "`stop_commands` for a list of possible values.\n"        )
+    __doc_stop_command = """
+        Reading returns the current stop command. Writing sets the stop command.
+        The value determines the motors behavior when `command` is set to `stop`.
+        Also, it determines the motors behavior when a run command completes. See
+        `stop_commands` for a list of possible values.
+        """
 
     stop_command = property( __get_stop_command, __set_stop_command, None, __doc_stop_command )
 
     def __get_stop_commands(self):
         return self._get_string_array_attribute( 'stop_commands', 'stop_commands' )
 
-    __doc_stop_commands = (
-        "Returns a list of stop modes supported by the motor controller.\n"
-        "Possible values are `coast`, `brake` and `hold`. `coast` means that power will\n"
-        "be removed from the motor and it will freely coast to a stop. `brake` means\n"
-        "that power will be removed from the motor and a passive electrical load will\n"
-        "be placed on the motor. This is usually done by shorting the motor terminals\n"
-        "together. This load will absorb the energy from the rotation of the motors and\n"
-        "cause the motor to stop more quickly than coasting. `hold` does not remove\n"
-        "power from the motor. Instead it actively try to hold the motor at the current\n"
-        "position. If an external force tries to turn the motor, the motor will 'push\n"
-        "back' to maintain its position.\n"        )
+    __doc_stop_commands = """
+        Returns a list of stop modes supported by the motor controller.
+        Possible values are `coast`, `brake` and `hold`. `coast` means that power will
+        be removed from the motor and it will freely coast to a stop. `brake` means
+        that power will be removed from the motor and a passive electrical load will
+        be placed on the motor. This is usually done by shorting the motor terminals
+        together. This load will absorb the energy from the rotation of the motors and
+        cause the motor to stop more quickly than coasting. `hold` does not remove
+        power from the motor. Instead it actively try to hold the motor at the current
+        position. If an external force tries to turn the motor, the motor will 'push
+        back' to maintain its position.
+        """
 
     stop_commands = property( __get_stop_commands, None, None, __doc_stop_commands )
 
@@ -485,10 +510,11 @@ class Motor(Device):
     def __set_time_sp(self, value):
         self._set_int_attribute( 'time_sp', 'time_sp', value )
 
-    __doc_time_sp = (
-        "Writing specifies the amount of time the motor will run when using the\n"
-        "`run-timed` command. Reading returns the current value. Units are in\n"
-        "milliseconds.\n"        )
+    __doc_time_sp = """
+        Writing specifies the amount of time the motor will run when using the
+        `run-timed` command. Reading returns the current value. Units are in
+        milliseconds.
+        """
 
     time_sp = property( __get_time_sp, __set_time_sp, None, __doc_time_sp )
 
@@ -610,37 +636,41 @@ class DcMotor(Device):
     def __set_command(self, value):
         self._set_string_attribute( 'command', 'command', value )
 
-    __doc_command = (
-        "Sets the command for the motor. Possible values are `run-forever`, `run-timed` and\n"
-        "`stop`. Not all commands may be supported, so be sure to check the contents\n"
-        "of the `commands` attribute.\n"        )
+    __doc_command = """
+        Sets the command for the motor. Possible values are `run-forever`, `run-timed` and
+        `stop`. Not all commands may be supported, so be sure to check the contents
+        of the `commands` attribute.
+        """
 
     command = property( None, __set_command, None, __doc_command )
 
     def __get_commands(self):
         return self._get_string_array_attribute( 'commands', 'commands' )
 
-    __doc_commands = (
-        "Returns a list of commands supported by the motor\n"
-        "controller.\n"        )
+    __doc_commands = """
+        Returns a list of commands supported by the motor
+        controller.
+        """
 
     commands = property( __get_commands, None, None, __doc_commands )
 
     def __get_driver_name(self):
         return self._get_string_attribute( 'driver_name', 'driver_name' )
 
-    __doc_driver_name = (
-        "Returns the name of the motor driver that loaded this device. See the list\n"
-        "of [supported devices] for a list of drivers.\n"        )
+    __doc_driver_name = """
+        Returns the name of the motor driver that loaded this device. See the list
+        of [supported devices] for a list of drivers.
+        """
 
     driver_name = property( __get_driver_name, None, None, __doc_driver_name )
 
     def __get_duty_cycle(self):
         return self._get_int_attribute( 'duty_cycle', 'duty_cycle' )
 
-    __doc_duty_cycle = (
-        "Shows the current duty cycle of the PWM signal sent to the motor. Values\n"
-        "are -100 to 100 (-100% to 100%).\n"        )
+    __doc_duty_cycle = """
+        Shows the current duty cycle of the PWM signal sent to the motor. Values
+        are -100 to 100 (-100% to 100%).
+        """
 
     duty_cycle = property( __get_duty_cycle, None, None, __doc_duty_cycle )
 
@@ -650,10 +680,11 @@ class DcMotor(Device):
     def __set_duty_cycle_sp(self, value):
         self._set_int_attribute( 'duty_cycle_sp', 'duty_cycle_sp', value )
 
-    __doc_duty_cycle_sp = (
-        "Writing sets the duty cycle setpoint of the PWM signal sent to the motor.\n"
-        "Valid values are -100 to 100 (-100% to 100%). Reading returns the current\n"
-        "setpoint.\n"        )
+    __doc_duty_cycle_sp = """
+        Writing sets the duty cycle setpoint of the PWM signal sent to the motor.
+        Valid values are -100 to 100 (-100% to 100%). Reading returns the current
+        setpoint.
+        """
 
     duty_cycle_sp = property( __get_duty_cycle_sp, __set_duty_cycle_sp, None, __doc_duty_cycle_sp )
 
@@ -663,16 +694,18 @@ class DcMotor(Device):
     def __set_polarity(self, value):
         self._set_string_attribute( 'polarity', 'polarity', value )
 
-    __doc_polarity = (
-        "Sets the polarity of the motor. Valid values are `normal` and `inversed`.\n"        )
+    __doc_polarity = """
+        Sets the polarity of the motor. Valid values are `normal` and `inversed`.
+        """
 
     polarity = property( __get_polarity, __set_polarity, None, __doc_polarity )
 
     def __get_port_name(self):
         return self._get_string_attribute( 'port_name', 'port_name' )
 
-    __doc_port_name = (
-        "Returns the name of the port that the motor is connected to.\n"        )
+    __doc_port_name = """
+        Returns the name of the port that the motor is connected to.
+        """
 
     port_name = property( __get_port_name, None, None, __doc_port_name )
 
@@ -682,9 +715,10 @@ class DcMotor(Device):
     def __set_ramp_down_sp(self, value):
         self._set_int_attribute( 'ramp_down_sp', 'ramp_down_sp', value )
 
-    __doc_ramp_down_sp = (
-        "Sets the time in milliseconds that it take the motor to ramp down from 100%\n"
-        "to 0%. Valid values are 0 to 10000 (10 seconds). Default is 0.\n"        )
+    __doc_ramp_down_sp = """
+        Sets the time in milliseconds that it take the motor to ramp down from 100%
+        to 0%. Valid values are 0 to 10000 (10 seconds). Default is 0.
+        """
 
     ramp_down_sp = property( __get_ramp_down_sp, __set_ramp_down_sp, None, __doc_ramp_down_sp )
 
@@ -694,38 +728,42 @@ class DcMotor(Device):
     def __set_ramp_up_sp(self, value):
         self._set_int_attribute( 'ramp_up_sp', 'ramp_up_sp', value )
 
-    __doc_ramp_up_sp = (
-        "Sets the time in milliseconds that it take the motor to up ramp from 0% to\n"
-        "100%. Valid values are 0 to 10000 (10 seconds). Default is 0.\n"        )
+    __doc_ramp_up_sp = """
+        Sets the time in milliseconds that it take the motor to up ramp from 0% to
+        100%. Valid values are 0 to 10000 (10 seconds). Default is 0.
+        """
 
     ramp_up_sp = property( __get_ramp_up_sp, __set_ramp_up_sp, None, __doc_ramp_up_sp )
 
     def __get_state(self):
         return self._get_string_array_attribute( 'state', 'state' )
 
-    __doc_state = (
-        "Gets a list of flags indicating the motor status. Possible\n"
-        "flags are `running` and `ramping`. `running` indicates that the motor is\n"
-        "powered. `ramping` indicates that the motor has not yet reached the\n"
-        "`duty_cycle_sp`.\n"        )
+    __doc_state = """
+        Gets a list of flags indicating the motor status. Possible
+        flags are `running` and `ramping`. `running` indicates that the motor is
+        powered. `ramping` indicates that the motor has not yet reached the
+        `duty_cycle_sp`.
+        """
 
     state = property( __get_state, None, None, __doc_state )
 
     def __set_stop_command(self, value):
         self._set_string_attribute( 'stop_command', 'stop_command', value )
 
-    __doc_stop_command = (
-        "Sets the stop command that will be used when the motor stops. Read\n"
-        "`stop_commands` to get the list of valid values.\n"        )
+    __doc_stop_command = """
+        Sets the stop command that will be used when the motor stops. Read
+        `stop_commands` to get the list of valid values.
+        """
 
     stop_command = property( None, __set_stop_command, None, __doc_stop_command )
 
     def __get_stop_commands(self):
         return self._get_string_array_attribute( 'stop_commands', 'stop_commands' )
 
-    __doc_stop_commands = (
-        "Gets a list of stop commands. Valid values are `coast`\n"
-        "and `brake`.\n"        )
+    __doc_stop_commands = """
+        Gets a list of stop commands. Valid values are `coast`
+        and `brake`.
+        """
 
     stop_commands = property( __get_stop_commands, None, None, __doc_stop_commands )
 
@@ -735,10 +773,11 @@ class DcMotor(Device):
     def __set_time_sp(self, value):
         self._set_int_attribute( 'time_sp', 'time_sp', value )
 
-    __doc_time_sp = (
-        "Writing specifies the amount of time the motor will run when using the\n"
-        "`run-timed` command. Reading returns the current value. Units are in\n"
-        "milliseconds.\n"        )
+    __doc_time_sp = """
+        Writing specifies the amount of time the motor will run when using the
+        `run-timed` command. Reading returns the current value. Units are in
+        milliseconds.
+        """
 
     time_sp = property( __get_time_sp, __set_time_sp, None, __doc_time_sp )
 
@@ -824,19 +863,21 @@ class ServoMotor(Device):
     def __set_command(self, value):
         self._set_string_attribute( 'command', 'command', value )
 
-    __doc_command = (
-        "Sets the command for the servo. Valid values are `run` and `float`. Setting\n"
-        "to `run` will cause the servo to be driven to the position_sp set in the\n"
-        "`position_sp` attribute. Setting to `float` will remove power from the motor.\n"        )
+    __doc_command = """
+        Sets the command for the servo. Valid values are `run` and `float`. Setting
+        to `run` will cause the servo to be driven to the position_sp set in the
+        `position_sp` attribute. Setting to `float` will remove power from the motor.
+        """
 
     command = property( None, __set_command, None, __doc_command )
 
     def __get_driver_name(self):
         return self._get_string_attribute( 'driver_name', 'driver_name' )
 
-    __doc_driver_name = (
-        "Returns the name of the motor driver that loaded this device. See the list\n"
-        "of [supported devices] for a list of drivers.\n"        )
+    __doc_driver_name = """
+        Returns the name of the motor driver that loaded this device. See the list
+        of [supported devices] for a list of drivers.
+        """
 
     driver_name = property( __get_driver_name, None, None, __doc_driver_name )
 
@@ -846,11 +887,12 @@ class ServoMotor(Device):
     def __set_max_pulse_sp(self, value):
         self._set_int_attribute( 'max_pulse_sp', 'max_pulse_sp', value )
 
-    __doc_max_pulse_sp = (
-        "Used to set the pulse size in milliseconds for the signal that tells the\n"
-        "servo to drive to the maximum (clockwise) position_sp. Default value is 2400.\n"
-        "Valid values are 2300 to 2700. You must write to the position_sp attribute for\n"
-        "changes to this attribute to take effect.\n"        )
+    __doc_max_pulse_sp = """
+        Used to set the pulse size in milliseconds for the signal that tells the
+        servo to drive to the maximum (clockwise) position_sp. Default value is 2400.
+        Valid values are 2300 to 2700. You must write to the position_sp attribute for
+        changes to this attribute to take effect.
+        """
 
     max_pulse_sp = property( __get_max_pulse_sp, __set_max_pulse_sp, None, __doc_max_pulse_sp )
 
@@ -860,13 +902,14 @@ class ServoMotor(Device):
     def __set_mid_pulse_sp(self, value):
         self._set_int_attribute( 'mid_pulse_sp', 'mid_pulse_sp', value )
 
-    __doc_mid_pulse_sp = (
-        "Used to set the pulse size in milliseconds for the signal that tells the\n"
-        "servo to drive to the mid position_sp. Default value is 1500. Valid\n"
-        "values are 1300 to 1700. For example, on a 180 degree servo, this would be\n"
-        "90 degrees. On continuous rotation servo, this is the 'neutral' position_sp\n"
-        "where the motor does not turn. You must write to the position_sp attribute for\n"
-        "changes to this attribute to take effect.\n"        )
+    __doc_mid_pulse_sp = """
+        Used to set the pulse size in milliseconds for the signal that tells the
+        servo to drive to the mid position_sp. Default value is 1500. Valid
+        values are 1300 to 1700. For example, on a 180 degree servo, this would be
+        90 degrees. On continuous rotation servo, this is the 'neutral' position_sp
+        where the motor does not turn. You must write to the position_sp attribute for
+        changes to this attribute to take effect.
+        """
 
     mid_pulse_sp = property( __get_mid_pulse_sp, __set_mid_pulse_sp, None, __doc_mid_pulse_sp )
 
@@ -876,11 +919,12 @@ class ServoMotor(Device):
     def __set_min_pulse_sp(self, value):
         self._set_int_attribute( 'min_pulse_sp', 'min_pulse_sp', value )
 
-    __doc_min_pulse_sp = (
-        "Used to set the pulse size in milliseconds for the signal that tells the\n"
-        "servo to drive to the miniumum (counter-clockwise) position_sp. Default value\n"
-        "is 600. Valid values are 300 to 700. You must write to the position_sp\n"
-        "attribute for changes to this attribute to take effect.\n"        )
+    __doc_min_pulse_sp = """
+        Used to set the pulse size in milliseconds for the signal that tells the
+        servo to drive to the miniumum (counter-clockwise) position_sp. Default value
+        is 600. Valid values are 300 to 700. You must write to the position_sp
+        attribute for changes to this attribute to take effect.
+        """
 
     min_pulse_sp = property( __get_min_pulse_sp, __set_min_pulse_sp, None, __doc_min_pulse_sp )
 
@@ -890,19 +934,21 @@ class ServoMotor(Device):
     def __set_polarity(self, value):
         self._set_string_attribute( 'polarity', 'polarity', value )
 
-    __doc_polarity = (
-        "Sets the polarity of the servo. Valid values are `normal` and `inversed`.\n"
-        "Setting the value to `inversed` will cause the position_sp value to be\n"
-        "inversed. i.e `-100` will correspond to `max_pulse_sp`, and `100` will\n"
-        "correspond to `min_pulse_sp`.\n"        )
+    __doc_polarity = """
+        Sets the polarity of the servo. Valid values are `normal` and `inversed`.
+        Setting the value to `inversed` will cause the position_sp value to be
+        inversed. i.e `-100` will correspond to `max_pulse_sp`, and `100` will
+        correspond to `min_pulse_sp`.
+        """
 
     polarity = property( __get_polarity, __set_polarity, None, __doc_polarity )
 
     def __get_port_name(self):
         return self._get_string_attribute( 'port_name', 'port_name' )
 
-    __doc_port_name = (
-        "Returns the name of the port that the motor is connected to.\n"        )
+    __doc_port_name = """
+        Returns the name of the port that the motor is connected to.
+        """
 
     port_name = property( __get_port_name, None, None, __doc_port_name )
 
@@ -912,11 +958,12 @@ class ServoMotor(Device):
     def __set_position_sp(self, value):
         self._set_int_attribute( 'position_sp', 'position_sp', value )
 
-    __doc_position_sp = (
-        "Reading returns the current position_sp of the servo. Writing instructs the\n"
-        "servo to move to the specified position_sp. Units are percent. Valid values\n"
-        "are -100 to 100 (-100% to 100%) where `-100` corresponds to `min_pulse_sp`,\n"
-        "`0` corresponds to `mid_pulse_sp` and `100` corresponds to `max_pulse_sp`.\n"        )
+    __doc_position_sp = """
+        Reading returns the current position_sp of the servo. Writing instructs the
+        servo to move to the specified position_sp. Units are percent. Valid values
+        are -100 to 100 (-100% to 100%) where `-100` corresponds to `min_pulse_sp`,
+        `0` corresponds to `mid_pulse_sp` and `100` corresponds to `max_pulse_sp`.
+        """
 
     position_sp = property( __get_position_sp, __set_position_sp, None, __doc_position_sp )
 
@@ -926,23 +973,25 @@ class ServoMotor(Device):
     def __set_rate_sp(self, value):
         self._set_int_attribute( 'rate_sp', 'rate_sp', value )
 
-    __doc_rate_sp = (
-        "Sets the rate_sp at which the servo travels from 0 to 100.0% (half of the full\n"
-        "range of the servo). Units are in milliseconds. Example: Setting the rate_sp\n"
-        "to 1000 means that it will take a 180 degree servo 2 second to move from 0\n"
-        "to 180 degrees. Note: Some servo controllers may not support this in which\n"
-        "case reading and writing will fail with `-EOPNOTSUPP`. In continuous rotation\n"
-        "servos, this value will affect the rate_sp at which the speed ramps up or down.\n"        )
+    __doc_rate_sp = """
+        Sets the rate_sp at which the servo travels from 0 to 100.0% (half of the full
+        range of the servo). Units are in milliseconds. Example: Setting the rate_sp
+        to 1000 means that it will take a 180 degree servo 2 second to move from 0
+        to 180 degrees. Note: Some servo controllers may not support this in which
+        case reading and writing will fail with `-EOPNOTSUPP`. In continuous rotation
+        servos, this value will affect the rate_sp at which the speed ramps up or down.
+        """
 
     rate_sp = property( __get_rate_sp, __set_rate_sp, None, __doc_rate_sp )
 
     def __get_state(self):
         return self._get_string_array_attribute( 'state', 'state' )
 
-    __doc_state = (
-        "Returns a list of flags indicating the state of the servo.\n"
-        "Possible values are:\n"
-        "* `running`: Indicates that the motor is powered.\n"        )
+    __doc_state = """
+        Returns a list of flags indicating the state of the servo.
+        Possible values are:
+        * `running`: Indicates that the motor is powered.
+        """
 
     state = property( __get_state, None, None, __doc_state )
 
@@ -1025,35 +1074,39 @@ class Sensor(Device):
     def __set_command(self, value):
         self._set_string_attribute( 'command', 'command', value )
 
-    __doc_command = (
-        "Sends a command to the sensor.\n"        )
+    __doc_command = """
+        Sends a command to the sensor.
+        """
 
     command = property( None, __set_command, None, __doc_command )
 
     def __get_commands(self):
         return self._get_string_array_attribute( 'commands', 'commands' )
 
-    __doc_commands = (
-        "Returns a list of the valid commands for the sensor.\n"
-        "Returns -EOPNOTSUPP if no commands are supported.\n"        )
+    __doc_commands = """
+        Returns a list of the valid commands for the sensor.
+        Returns -EOPNOTSUPP if no commands are supported.
+        """
 
     commands = property( __get_commands, None, None, __doc_commands )
 
     def __get_decimals(self):
         return self._get_int_attribute( 'decimals', 'decimals' )
 
-    __doc_decimals = (
-        "Returns the number of decimal places for the values in the `value<N>`\n"
-        "attributes of the current mode.\n"        )
+    __doc_decimals = """
+        Returns the number of decimal places for the values in the `value<N>`
+        attributes of the current mode.
+        """
 
     decimals = property( __get_decimals, None, None, __doc_decimals )
 
     def __get_driver_name(self):
         return self._get_string_attribute( 'driver_name', 'driver_name' )
 
-    __doc_driver_name = (
-        "Returns the name of the sensor device/driver. See the list of [supported\n"
-        "sensors] for a complete list of drivers.\n"        )
+    __doc_driver_name = """
+        Returns the name of the sensor device/driver. See the list of [supported
+        sensors] for a complete list of drivers.
+        """
 
     driver_name = property( __get_driver_name, None, None, __doc_driver_name )
 
@@ -1063,44 +1116,49 @@ class Sensor(Device):
     def __set_mode(self, value):
         self._set_string_attribute( 'mode', 'mode', value )
 
-    __doc_mode = (
-        "Returns the current mode. Writing one of the values returned by `modes`\n"
-        "sets the sensor to that mode.\n"        )
+    __doc_mode = """
+        Returns the current mode. Writing one of the values returned by `modes`
+        sets the sensor to that mode.
+        """
 
     mode = property( __get_mode, __set_mode, None, __doc_mode )
 
     def __get_modes(self):
         return self._get_string_array_attribute( 'modes', 'modes' )
 
-    __doc_modes = (
-        "Returns a list of the valid modes for the sensor.\n"        )
+    __doc_modes = """
+        Returns a list of the valid modes for the sensor.
+        """
 
     modes = property( __get_modes, None, None, __doc_modes )
 
     def __get_num_values(self):
         return self._get_int_attribute( 'num_values', 'num_values' )
 
-    __doc_num_values = (
-        "Returns the number of `value<N>` attributes that will return a valid value\n"
-        "for the current mode.\n"        )
+    __doc_num_values = """
+        Returns the number of `value<N>` attributes that will return a valid value
+        for the current mode.
+        """
 
     num_values = property( __get_num_values, None, None, __doc_num_values )
 
     def __get_port_name(self):
         return self._get_string_attribute( 'port_name', 'port_name' )
 
-    __doc_port_name = (
-        "Returns the name of the port that the sensor is connected to, e.g. `ev3:in1`.\n"
-        "I2C sensors also include the I2C address (decimal), e.g. `ev3:in1:i2c8`.\n"        )
+    __doc_port_name = """
+        Returns the name of the port that the sensor is connected to, e.g. `ev3:in1`.
+        I2C sensors also include the I2C address (decimal), e.g. `ev3:in1:i2c8`.
+        """
 
     port_name = property( __get_port_name, None, None, __doc_port_name )
 
     def __get_units(self):
         return self._get_string_attribute( 'units', 'units' )
 
-    __doc_units = (
-        "Returns the units of the measured value for the current mode. May return\n"
-        "empty string\n"        )
+    __doc_units = """
+        Returns the units of the measured value for the current mode. May return
+        empty string
+        """
 
     units = property( __get_units, None, None, __doc_units )
 
@@ -1140,9 +1198,10 @@ class I2cSensor(Device):
     def __get_fw_version(self):
         return self._get_string_attribute( 'fw_version', 'fw_version' )
 
-    __doc_fw_version = (
-        "Returns the firmware version of the sensor if available. Currently only\n"
-        "I2C/NXT sensors support this.\n"        )
+    __doc_fw_version = """
+        Returns the firmware version of the sensor if available. Currently only
+        I2C/NXT sensors support this.
+        """
 
     fw_version = property( __get_fw_version, None, None, __doc_fw_version )
 
@@ -1152,11 +1211,12 @@ class I2cSensor(Device):
     def __set_poll_ms(self, value):
         self._set_int_attribute( 'poll_ms', 'poll_ms', value )
 
-    __doc_poll_ms = (
-        "Returns the polling period of the sensor in milliseconds. Writing sets the\n"
-        "polling period. Setting to 0 disables polling. Minimum value is hard\n"
-        "coded as 50 msec. Returns -EOPNOTSUPP if changing polling is not supported.\n"
-        "Currently only I2C/NXT sensors support changing the polling period.\n"        )
+    __doc_poll_ms = """
+        Returns the polling period of the sensor in milliseconds. Writing sets the
+        polling period. Setting to 0 disables polling. Minimum value is hard
+        coded as 50 msec. Returns -EOPNOTSUPP if changing polling is not supported.
+        Currently only I2C/NXT sensors support changing the polling period.
+        """
 
     poll_ms = property( __get_poll_ms, __set_poll_ms, None, __doc_poll_ms )
 
@@ -1350,8 +1410,9 @@ class Led(Device):
     def __get_max_brightness(self):
         return self._get_int_attribute( 'max_brightness', 'max_brightness' )
 
-    __doc_max_brightness = (
-        "Returns the maximum allowable brightness value.\n"        )
+    __doc_max_brightness = """
+        Returns the maximum allowable brightness value.
+        """
 
     max_brightness = property( __get_max_brightness, None, None, __doc_max_brightness )
 
@@ -1361,16 +1422,18 @@ class Led(Device):
     def __set_brightness(self, value):
         self._set_int_attribute( 'brightness', 'brightness', value )
 
-    __doc_brightness = (
-        "Sets the brightness level. Possible values are from 0 to `max_brightness`.\n"        )
+    __doc_brightness = """
+        Sets the brightness level. Possible values are from 0 to `max_brightness`.
+        """
 
     brightness = property( __get_brightness, __set_brightness, None, __doc_brightness )
 
     def __get_triggers(self):
         return self._get_string_array_attribute( 'triggers', 'trigger' )
 
-    __doc_triggers = (
-        "Returns a list of available triggers.\n"        )
+    __doc_triggers = """
+        Returns a list of available triggers.
+        """
 
     triggers = property( __get_triggers, None, None, __doc_triggers )
 
@@ -1380,21 +1443,22 @@ class Led(Device):
     def __set_trigger(self, value):
         self._set_string_selector_attribute( 'trigger', 'trigger', value )
 
-    __doc_trigger = (
-        "Sets the led trigger. A trigger\n"
-        "is a kernel based source of led events. Triggers can either be simple or\n"
-        "complex. A simple trigger isn't configurable and is designed to slot into\n"
-        "existing subsystems with minimal additional code. Examples are the `ide-disk` and\n"
-        "`nand-disk` triggers.\n"
-        "\n"
-        "Complex triggers whilst available to all LEDs have LED specific\n"
-        "parameters and work on a per LED basis. The `timer` trigger is an example.\n"
-        "The `timer` trigger will periodically change the LED brightness between\n"
-        "0 and the current brightness setting. The `on` and `off` time can\n"
-        "be specified via `delay_{on,off}` attributes in milliseconds.\n"
-        "You can change the brightness value of a LED independently of the timer\n"
-        "trigger. However, if you set the brightness value to 0 it will\n"
-        "also disable the `timer` trigger.\n"        )
+    __doc_trigger = """
+        Sets the led trigger. A trigger
+        is a kernel based source of led events. Triggers can either be simple or
+        complex. A simple trigger isn't configurable and is designed to slot into
+        existing subsystems with minimal additional code. Examples are the `ide-disk` and
+        `nand-disk` triggers.
+        
+        Complex triggers whilst available to all LEDs have LED specific
+        parameters and work on a per LED basis. The `timer` trigger is an example.
+        The `timer` trigger will periodically change the LED brightness between
+        0 and the current brightness setting. The `on` and `off` time can
+        be specified via `delay_{on,off}` attributes in milliseconds.
+        You can change the brightness value of a LED independently of the timer
+        trigger. However, if you set the brightness value to 0 it will
+        also disable the `timer` trigger.
+        """
 
     trigger = property( __get_trigger, __set_trigger, None, __doc_trigger )
 
@@ -1404,10 +1468,11 @@ class Led(Device):
     def __set_delay_on(self, value):
         self._set_int_attribute( 'delay_on', 'delay_on', value )
 
-    __doc_delay_on = (
-        "The `timer` trigger will periodically change the LED brightness between\n"
-        "0 and the current brightness setting. The `on` time can\n"
-        "be specified via `delay_on` attribute in milliseconds.\n"        )
+    __doc_delay_on = """
+        The `timer` trigger will periodically change the LED brightness between
+        0 and the current brightness setting. The `on` time can
+        be specified via `delay_on` attribute in milliseconds.
+        """
 
     delay_on = property( __get_delay_on, __set_delay_on, None, __doc_delay_on )
 
@@ -1417,10 +1482,11 @@ class Led(Device):
     def __set_delay_off(self, value):
         self._set_int_attribute( 'delay_off', 'delay_off', value )
 
-    __doc_delay_off = (
-        "The `timer` trigger will periodically change the LED brightness between\n"
-        "0 and the current brightness setting. The `off` time can\n"
-        "be specified via `delay_off` attribute in milliseconds.\n"        )
+    __doc_delay_off = """
+        The `timer` trigger will periodically change the LED brightness between
+        0 and the current brightness setting. The `off` time can
+        be specified via `delay_off` attribute in milliseconds.
+        """
 
     delay_off = property( __get_delay_off, __set_delay_off, None, __doc_delay_off )
 
@@ -1449,44 +1515,50 @@ class PowerSupply(Device):
     def __get_measured_current(self):
         return self._get_int_attribute( 'measured_current', 'current_now' )
 
-    __doc_measured_current = (
-        "The measured current that the battery is supplying (in microamps)\n"        )
+    __doc_measured_current = """
+        The measured current that the battery is supplying (in microamps)
+        """
 
     measured_current = property( __get_measured_current, None, None, __doc_measured_current )
 
     def __get_measured_voltage(self):
         return self._get_int_attribute( 'measured_voltage', 'voltage_now' )
 
-    __doc_measured_voltage = (
-        "The measured voltage that the battery is supplying (in microvolts)\n"        )
+    __doc_measured_voltage = """
+        The measured voltage that the battery is supplying (in microvolts)
+        """
 
     measured_voltage = property( __get_measured_voltage, None, None, __doc_measured_voltage )
 
     def __get_max_voltage(self):
         return self._get_int_attribute( 'max_voltage', 'voltage_max_design' )
 
-    __doc_max_voltage = (        )
+    __doc_max_voltage = """
+        """
 
     max_voltage = property( __get_max_voltage, None, None, __doc_max_voltage )
 
     def __get_min_voltage(self):
         return self._get_int_attribute( 'min_voltage', 'voltage_min_design' )
 
-    __doc_min_voltage = (        )
+    __doc_min_voltage = """
+        """
 
     min_voltage = property( __get_min_voltage, None, None, __doc_min_voltage )
 
     def __get_technology(self):
         return self._get_string_attribute( 'technology', 'technology' )
 
-    __doc_technology = (        )
+    __doc_technology = """
+        """
 
     technology = property( __get_technology, None, None, __doc_technology )
 
     def __get_type(self):
         return self._get_string_attribute( 'type', 'type' )
 
-    __doc_type = (        )
+    __doc_type = """
+        """
 
     type = property( __get_type, None, None, __doc_type )
 
@@ -1538,17 +1610,19 @@ class LegoPort(Device):
     def __get_driver_name(self):
         return self._get_string_attribute( 'driver_name', 'driver_name' )
 
-    __doc_driver_name = (
-        "Returns the name of the driver that loaded this device. You can find the\n"
-        "complete list of drivers in the [list of port drivers].\n"        )
+    __doc_driver_name = """
+        Returns the name of the driver that loaded this device. You can find the
+        complete list of drivers in the [list of port drivers].
+        """
 
     driver_name = property( __get_driver_name, None, None, __doc_driver_name )
 
     def __get_modes(self):
         return self._get_string_array_attribute( 'modes', 'modes' )
 
-    __doc_modes = (
-        "Returns a list of the available modes of the port.\n"        )
+    __doc_modes = """
+        Returns a list of the available modes of the port.
+        """
 
     modes = property( __get_modes, None, None, __doc_modes )
 
@@ -1558,43 +1632,47 @@ class LegoPort(Device):
     def __set_mode(self, value):
         self._set_string_attribute( 'mode', 'mode', value )
 
-    __doc_mode = (
-        "Reading returns the currently selected mode. Writing sets the mode.\n"
-        "Generally speaking when the mode changes any sensor or motor devices\n"
-        "associated with the port will be removed new ones loaded, however this\n"
-        "this will depend on the individual driver implementing this class.\n"        )
+    __doc_mode = """
+        Reading returns the currently selected mode. Writing sets the mode.
+        Generally speaking when the mode changes any sensor or motor devices
+        associated with the port will be removed new ones loaded, however this
+        this will depend on the individual driver implementing this class.
+        """
 
     mode = property( __get_mode, __set_mode, None, __doc_mode )
 
     def __get_port_name(self):
         return self._get_string_attribute( 'port_name', 'port_name' )
 
-    __doc_port_name = (
-        "Returns the name of the port. See individual driver documentation for\n"
-        "the name that will be returned.\n"        )
+    __doc_port_name = """
+        Returns the name of the port. See individual driver documentation for
+        the name that will be returned.
+        """
 
     port_name = property( __get_port_name, None, None, __doc_port_name )
 
     def __set_set_device(self, value):
         self._set_string_attribute( 'set_device', 'set_device', value )
 
-    __doc_set_device = (
-        "For modes that support it, writing the name of a driver will cause a new\n"
-        "device to be registered for that driver and attached to this port. For\n"
-        "example, since NXT/Analog sensors cannot be auto-detected, you must use\n"
-        "this attribute to load the correct driver. Returns -EOPNOTSUPP if setting a\n"
-        "device is not supported.\n"        )
+    __doc_set_device = """
+        For modes that support it, writing the name of a driver will cause a new
+        device to be registered for that driver and attached to this port. For
+        example, since NXT/Analog sensors cannot be auto-detected, you must use
+        this attribute to load the correct driver. Returns -EOPNOTSUPP if setting a
+        device is not supported.
+        """
 
     set_device = property( None, __set_set_device, None, __doc_set_device )
 
     def __get_status(self):
         return self._get_string_attribute( 'status', 'status' )
 
-    __doc_status = (
-        "In most cases, reading status will return the same value as `mode`. In\n"
-        "cases where there is an `auto` mode additional values may be returned,\n"
-        "such as `no-device` or `error`. See individual port driver documentation\n"
-        "for the full list of possible values.\n"        )
+    __doc_status = """
+        In most cases, reading status will return the same value as `mode`. In
+        cases where there is an `auto` mode additional values may be returned,
+        such as `no-device` or `error`. See individual port driver documentation
+        for the full list of possible values.
+        """
 
     status = property( __get_status, None, None, __doc_status )
 

--- a/ev3dev/ev3dev.py
+++ b/ev3dev/ev3dev.py
@@ -557,59 +557,64 @@ class Motor(Device):
 #~autogen
 #~autogen python_generic-helper-function classes.motor>currentClass
 
-    _properties = {
-	      'command' : __set_command
-	    , 'duty_cycle_sp' : __set_duty_cycle_sp
-	    , 'encoder_polarity' : __set_encoder_polarity
-	    , 'polarity' : __set_polarity
-	    , 'position' : __set_position
-	    , 'position_p' : __set_position_p
-	    , 'position_i' : __set_position_i
-	    , 'position_d' : __set_position_d
-	    , 'position_sp' : __set_position_sp
-	    , 'speed_sp' : __set_speed_sp
-	    , 'ramp_up_sp' : __set_ramp_up_sp
-	    , 'ramp_down_sp' : __set_ramp_down_sp
-	    , 'speed_regulation_enabled' : __set_speed_regulation_enabled
-	    , 'speed_regulation_p' : __set_speed_regulation_p
-	    , 'speed_regulation_i' : __set_speed_regulation_i
-	    , 'speed_regulation_d' : __set_speed_regulation_d
-	    , 'stop_command' : __set_stop_command
-	    , 'time_sp' : __set_time_sp }
-
-    def _helper( self, **kwargs ):
-        for p,v in kwargs.iteritems():
-            if p in self._properties:
-                self._properties[p]( self, v )
-
     def run_forever( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'run-forever' )
-	
+        """Run the motor until another command is sent.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'run-forever'
+
     def run_to_abs_pos( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'run-to-abs-pos' )
-	
+        """Run to an absolute position specified by `position_sp` and then
+        stop using the command specified in `stop_command`.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'run-to-abs-pos'
+
     def run_to_rel_pos( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'run-to-rel-pos' )
-	
+        """Run to a position relative to the current `position` value.
+        The new position will be current `position` + `position_sp`.
+        When the new position is reached, the motor will stop using
+        the command specified by `stop_command`.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'run-to-rel-pos'
+
     def run_timed( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'run-timed' )
-	
+        """Run the motor for the amount of time specified in `time_sp`
+        and then stop the motor using the command specified by `stop_command`.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'run-timed'
+
     def run_direct( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'run-direct' )
-	
+        """Run the motor at the duty cycle specified by `duty_cycle_sp`.
+        Unlike other run commands, changing `duty_cycle_sp` while running *will*
+        take effect immediately.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'run-direct'
+
     def stop( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'stop' )
-	
+        """Stop any of the run commands before they are complete using the
+        command specified by `stop_command`.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'stop'
+
     def reset( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'reset' )
-	
+        """Reset all of the motor parameter attributes to their default value.
+        This will also have the effect of stopping the motor.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'reset'
+
 
 #~autogen
 #~autogen python_generic-class classes.dcMotor>currentClass
@@ -807,36 +812,38 @@ class DcMotor(Device):
 
 #~autogen python_generic-helper-function classes.dcMotor>currentClass
 
-    _properties = {
-	      'command' : __set_command
-	    , 'duty_cycle_sp' : __set_duty_cycle_sp
-	    , 'polarity' : __set_polarity
-	    , 'ramp_down_sp' : __set_ramp_down_sp
-	    , 'ramp_up_sp' : __set_ramp_up_sp
-	    , 'stop_command' : __set_stop_command
-	    , 'time_sp' : __set_time_sp }
-
-    def _helper( self, **kwargs ):
-        for p,v in kwargs.iteritems():
-            if p in self._properties:
-                self._properties[p]( self, v )
-
     def run_forever( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'run-forever' )
-	
+        """Run the motor until another command is sent.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'run-forever'
+
     def run_timed( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'run-timed' )
-	
+        """Run the motor for the amount of time specified in `time_sp`
+        and then stop the motor using the command specified by `stop_command`.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'run-timed'
+
     def run_direct( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'run-direct' )
-	
+        """Run the motor at the duty cycle specified by `duty_cycle_sp`.
+        Unlike other run commands, changing `duty_cycle_sp` while running *will*
+        take effect immediately.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'run-direct'
+
     def stop( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'stop' )
-	
+        """Stop any of the run commands before they are complete using the
+        command specified by `stop_command`.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'stop'
+
 
 #~autogen
 
@@ -1014,28 +1021,20 @@ class ServoMotor(Device):
 
 #~autogen python_generic-helper-function classes.servoMotor>currentClass
 
-    _properties = {
-	      'command' : __set_command
-	    , 'max_pulse_sp' : __set_max_pulse_sp
-	    , 'mid_pulse_sp' : __set_mid_pulse_sp
-	    , 'min_pulse_sp' : __set_min_pulse_sp
-	    , 'polarity' : __set_polarity
-	    , 'position_sp' : __set_position_sp
-	    , 'rate_sp' : __set_rate_sp }
-
-    def _helper( self, **kwargs ):
-        for p,v in kwargs.iteritems():
-            if p in self._properties:
-                self._properties[p]( self, v )
-
     def run( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'run' )
-	
+        """Drive servo to the position set in the `position_sp` attribute.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'run'
+
     def float( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', 'float' )
-	
+        """Remove power from the motor.
+        """
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = 'float'
+
 
 #~autogen
 

--- a/templates/python_generic-class.liquid
+++ b/templates/python_generic-class.liquid
@@ -1,5 +1,5 @@
 {% assign class_name = currentClass.friendlyName | camel_case | capitalize %}
-{% assign device_name_convention = currentClass.systemDeviceNameConvention | replace: '\{0\}', '*' %} 
+{% assign device_name_convention = currentClass.systemDeviceNameConvention | replace: '\{0\}', '*' %}
 class {{ class_name }}(Device):
 
     """{% for line in currentClass.description %}

--- a/templates/python_generic-get-set.liquid
+++ b/templates/python_generic-get-set.liquid
@@ -12,10 +12,11 @@ for prop in currentClass.systemProperties %}{%
         self._set_{{ prop.type | underscore_spaces }}_attribute( '{{ prop_name }}', '{{ prop.systemName }}', value ){%
   endif %}
 
-    __doc_{{ prop_name }} = ({%
+    __doc_{{ prop_name }} = """{%
   for line in prop.description %}
-        "{{ line }}\n"{%
-  endfor %}        ){%
+        {{ line }}{%
+  endfor %}
+        """{%
   if prop.readAccess and prop.writeAccess %}
 
     {{ prop_name }} = property( __get_{{ prop_name }}, __set_{{ prop_name }}, None, __doc_{{ prop_name }} ){%

--- a/templates/python_generic-helper-function.liquid
+++ b/templates/python_generic-helper-function.liquid
@@ -7,7 +7,7 @@
         endif %}{%
     endfor %}
 {{ properties | replace_first:',',' ' }} }
-    
+
     def _helper( self, **kwargs ):
         for p,v in kwargs.iteritems():
             if p in self._properties:
@@ -21,7 +21,7 @@
 	self._set_string_attribute( 'command', 'command', '{{ value.name }}' )
 	{% endfor %}{%
 	endif %}{%
-    endfor %}{%	
+    endfor %}{%
 comment %}{%
 for func in currentClass.helperFunctions %}{%
 assign func_name = func.name | downcase | underscore_spaces %}{%

--- a/templates/python_generic-helper-function.liquid
+++ b/templates/python_generic-helper-function.liquid
@@ -1,36 +1,16 @@
 {% assign class_name = currentClass.friendlyName | camel_case | capitalize %}{%
-    assign properties = "    _properties = {" %}{%
-    for propval in currentClass.systemProperties %}{%
-        if propval.writeAccess %}{%
-            capture properties %}{{ properties }}
-	    , '{{ propval.name | replace:' ','_' | downcase }}' : __set_{{ propval.name | replace:' ','_' | downcase }}{% endcapture %}{%
-        endif %}{%
-    endfor %}
-{{ properties | replace_first:',',' ' }} }
-
-    def _helper( self, **kwargs ):
-        for p,v in kwargs.iteritems():
-            if p in self._properties:
-                self._properties[p]( self, v )
-{%  for propval in currentClass.propertyValues %}{%
-	if propval.propertyName == "Command" %}{%
-	    for value in propval.values %}{%
-                assign cmd = value.name | replace:'-','_' %}
+for propval in currentClass.propertyValues %}{%
+    if propval.propertyName == "Command" %}{%
+        for value in propval.values %}{%
+            assign cmd = value.name | replace:'-','_' %}
     def {{ cmd }}( self, **kwargs ):
-        self._helper( **kwargs )
-	self._set_string_attribute( 'command', 'command', '{{ value.name }}' )
-	{% endfor %}{%
-	endif %}{%
-    endfor %}{%
-comment %}{%
-for func in currentClass.helperFunctions %}{%
-assign func_name = func.name | downcase | underscore_spaces %}{%
-    assign param_list = "" %}{%
-    for param in func.parameters %}{%
-        capture param_list %}{{ param_list }}, {{ param.name }}{% endcapture %}{%
-    endfor %}
-    def {{ func_name }}( {{ param_list | remove_first:', ' }} ):
-        pass {%
-endfor %}{%
+        """{%
+        for line in value.description %}{{line}}
+        {% endfor %}"""
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.command = '{{value.name}}'
+{%
+        endfor %}{%
+    endif %}{%
 endfor %}
-{% endcomment %}

--- a/templates/python_generic-property-value.liquid
+++ b/templates/python_generic-property-value.liquid
@@ -2,9 +2,7 @@
   assign className = currentClass.friendlyName | downcase | underscore_spaces %}{%
   assign propName = prop.propertyName | downcase | underscore_spaces %}
 
-    __propval_{{propName}} = { {%
-  for value in prop.values %} 
-      '{{value.name}}':'{{value.description}}' ,{%
-  endfor %}
-          }{%
+    __propval_{{propName}} = {
+{% for value in prop.values %}      '{{value.name}}':'{{value.description}}' ,
+{% endfor %}      }{%
 endfor %}


### PR DESCRIPTION
This gets rid of trailing spaces in both source and generated files, formats docstrings as multiline python strings, and, most importantly, cleans up helper motor functions.

There is no need to create `_properties` dict and `_helper()` function.  `setarg(self, key, kwargs[key])` will access the correct property and deal with property type (string, int, etc) automatically.