### PR TITLE
Make Device constructor more generic 

### DIFF
--- a/ev3dev/__init__.py
+++ b/ev3dev/__init__.py
@@ -1,1 +1,2 @@
+__all__ = ['ev3dev']
 from ev3dev import *

--- a/templates/python_generic-class.liquid
+++ b/templates/python_generic-class.liquid
@@ -9,5 +9,5 @@ class {{ class_name }}(Device):
     SYSTEM_CLASS_NAME = '{{ currentClass.systemClassName }}'
     SYSTEM_DEVICE_NAME_CONVENTION = '{{ device_name_convention }}'
 
-    def __init__(self, port='auto', name='*' ):
-        Device.__init__( self, self.SYSTEM_CLASS_NAME, port, name )
+    def __init__(self, port='', name='*', **kwargs ):
+        Device.__init__( self, self.SYSTEM_CLASS_NAME, name, port_name=port, **kwargs )


### PR DESCRIPTION
The previous version of `Device.__init__` took three positional arguments:
class name (`'tacho-motor'`), device name pattern (`'motor*'` or just `'*'`),
and port name (`'outA'`).

The new version takes two positional arguments (class name and device
name) and an arbitrary set of keyword arguments. The keyword arguments
are used for matching against device attributes. A match is considered a
match when the provided value is a substring of attribute value. If a
list is provided as keyword argument, then a match against any single
entry of the list is enough.

Compare the previous call:
```py
d = Device('tacho-motor', 'outA', 'motor*')
```
with the new calls
```py
# Get a motor on output port A:
d = Device('tacho-motor', 'motor*', port_name='outA')

# Get large motor on output port A:
m = Device('tacho-motor', port_name='outA', driver_name='lego-ev3-l-motor')

# Get an ultrasonic sensor (don't care if EV3 one or NXT one):
m = Device('lego-sensor', driver_name=['lego-ev3-us', 'lego-nxt-us'])
```
This would allow for easy implementation of such classes as `LargeMotor`
or `MediumMotor`.  This also makes Device constructor interface compatible
with boostc version of python bindings.