### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(
     license='MIT',
     url='https://github.com/rhempel/ev3dev-lang-python',
     include_package_data=True,
-    packages=['ev3dev']
+    py_modules=['ev3dev']
     )
 


### PR DESCRIPTION
Replace `packages` clause with `py_modules`.

See @ericpascual's comment https://github.com/rhempel/ev3dev-lang-python/issues/10#issuecomment-149635524 and https://docs.python.org/2/distutils/setupscript.html#listing-individual-modules