### PR TITLE
Implement FbMem and LCD classes

### DIFF
--- a/ev3dev.py
+++ b/ev3dev.py
@@ -2141,7 +2141,7 @@ class FbMem(object):
             offset=0
         )
 
-class LCD(FbMem):
+class Screen(FbMem):
     """
     A convenience wrapper for the FbMem class.
     Provides drawing functions from the python imaging library (PIL).
@@ -2162,28 +2162,28 @@ class LCD(FbMem):
     @property
     def xres(self):
         """
-        Horizontal LCD screen resolution
+        Horizontal screen resolution
         """
         return self.var_info.xres
 
     @property
     def yres(self):
         """
-        Vertical LCD screen resolution
+        Vertical screen resolution
         """
         return self.var_info.yres
 
     @property
     def shape(self):
         """
-        Dimensions of the LCD screen.
+        Dimensions of the screen.
         """
         return (self.xres, self.yres)
 
     @property
     def draw(self):
         """
-        Returns a handle to PIL.ImageDraw.Draw class associated with LCD.
+        Returns a handle to PIL.ImageDraw.Draw class associated with the screen.
         Example::
             lcd.draw.rectangle((10,10,60,20), fill='black')
         """
@@ -2191,13 +2191,13 @@ class LCD(FbMem):
 
     def clear(self):
         """
-        Clears the LCD screen
+        Clears the screen
         """
         self._draw.rectangle(((0,0), self.shape), fill="white")
 
     def update(self):
         """
-        Applies pending changes to the LCD.
+        Applies pending changes to the screen.
         Nothing will be drawn on the screen until this function is called.
         """
         self.mmap[:] = self._img.tobytes("raw", "1;IR")

--- a/ev3dev.py
+++ b/ev3dev.py
@@ -2157,7 +2157,7 @@ class LCD(FbMem):
 
         self._img = Image.new("1", (alignup(self.xres, 32), self.yres), "white")
 
-        self.draw = ImageDraw.Draw(self._img)
+        self._draw = ImageDraw.Draw(self._img)
 
     @property
     def xres(self):
@@ -2187,13 +2187,13 @@ class LCD(FbMem):
         Example::
             lcd.draw.rectangle((10,10,60,20), fill='black')
         """
-        return self.draw
+        return self._draw
 
     def clear(self):
         """
         Clears the LCD screen
         """
-        self.draw.rectangle(((0,0), self.shape), fill="white")
+        self._draw.rectangle(((0,0), self.shape), fill="white")
 
     def update(self):
         """

--- a/ev3dev.py
+++ b/ev3dev.py
@@ -27,12 +27,16 @@
 
 #~autogen
 
+import os
 import os.path
 import fnmatch
 import numbers
 import platform
 import fcntl
 import array
+import mmap
+import ctypes
+from PIL import Image, ImageDraw
 
 #------------------------------------------------------------------------------
 # Guess platform we are running on
@@ -1986,4 +1990,215 @@ class LegoPort(Device):
 
 
 #~autogen
+
+class FbMem(object):
+
+    """The framebuffer memory object.
+
+    Made of:
+        - the framebuffer file descriptor
+        - the fix screen info struct
+        - the var screen info struct
+        - the mapped memory
+    """
+
+    #-------------------------------------------------------------------
+    # The code is adapted from
+    # https://github.com/LinkCareServices/cairotft/blob/master/cairotft/linuxfb.py
+    #
+    # The original code came with the following license:
+    #-------------------------------------------------------------------
+    # Copyright (c) 2012 Kurichan
+    #
+    # This program is free software. It comes without any warranty, to
+    # the extent permitted by applicable law. You can redistribute it
+    # and/or modify it under the terms of the Do What The Fuck You Want
+    # To Public License, Version 2, as published by Sam Hocevar. See
+    # http://sam.zoy.org/wtfpl/COPYING for more details.
+    #-------------------------------------------------------------------
+
+
+    __slots__ = ('fid', 'fix_info', 'var_info', 'mmap')
+
+    FBIOGET_VSCREENINFO = 0x4600
+    FBIOGET_FSCREENINFO = 0x4602
+
+    class FixScreenInfo(ctypes.Structure):
+
+        """The fb_fix_screeninfo from fb.h."""
+
+        _fields_ = [
+            ('id_name', ctypes.c_char * 16),
+            ('smem_start', ctypes.c_ulong),
+            ('smem_len', ctypes.c_uint32),
+            ('type', ctypes.c_uint32),
+            ('type_aux', ctypes.c_uint32),
+            ('visual', ctypes.c_uint32),
+            ('xpanstep', ctypes.c_uint16),
+            ('ypanstep', ctypes.c_uint16),
+            ('ywrapstep', ctypes.c_uint16),
+            ('line_length', ctypes.c_uint32),
+            ('mmio_start', ctypes.c_ulong),
+            ('mmio_len', ctypes.c_uint32),
+            ('accel', ctypes.c_uint32),
+            ('reserved', ctypes.c_uint16 * 3),
+        ]
+
+
+    class VarScreenInfo(ctypes.Structure):
+
+        class FbBitField(ctypes.Structure):
+
+            """The fb_bitfield struct from fb.h."""
+
+            _fields_ = [
+                ('offset', ctypes.c_uint32),
+                ('length', ctypes.c_uint32),
+                ('msb_right', ctypes.c_uint32),
+            ]
+
+
+        """The fb_var_screeninfo struct from fb.h."""
+
+        _fields_ = [
+            ('xres', ctypes.c_uint32),
+            ('yres', ctypes.c_uint32),
+            ('xres_virtual', ctypes.c_uint32),
+            ('yres_virtual', ctypes.c_uint32),
+            ('xoffset', ctypes.c_uint32),
+            ('yoffset', ctypes.c_uint32),
+
+            ('bits_per_pixel', ctypes.c_uint32),
+            ('grayscale', ctypes.c_uint32),
+
+            ('red', FbBitField),
+            ('green', FbBitField),
+            ('blue', FbBitField),
+            ('transp', FbBitField),
+        ]
+
+
+    def __init__(self, fbdev=None):
+        """Create the FbMem framebuffer memory object."""
+        fid = FbMem._open_fbdev(fbdev)
+        fix_info = FbMem._get_fix_info(fid)
+        fbmmap = FbMem._map_fb_memory(fid, fix_info)
+        self.fid = fid
+        self.fix_info = fix_info
+        self.var_info = FbMem._get_var_info(fid)
+        self.mmap = fbmmap
+
+
+    def __del__(self):
+        """Close the FbMem framebuffer memory object."""
+        self.mmap.close()
+        FbMem._close_fbdev(self.fid)
+
+
+    @staticmethod
+    def _open_fbdev(fbdev=None):
+        """Return the framebuffer file descriptor.
+
+        Try to use the FRAMEBUFFER
+        environment variable if fbdev is not given. Use '/dev/fb0' by
+        default.
+        """
+        dev = fbdev or os.getenv('FRAMEBUFFER', '/dev/fb0')
+        fbfid = os.open(dev, os.O_RDWR)
+        return fbfid
+
+
+    @staticmethod
+    def _close_fbdev(fbfid):
+        """Close the framebuffer file descriptor."""
+        os.close(fbfid)
+
+
+    @staticmethod
+    def _get_fix_info(fbfid):
+        """Return the fix screen info from the framebuffer file descriptor."""
+        fix_info = FbMem.FixScreenInfo()
+        fcntl.ioctl(fbfid, FbMem.FBIOGET_FSCREENINFO, fix_info)
+        return fix_info
+
+
+    @staticmethod
+    def _get_var_info(fbfid):
+        """Return the var screen info from the framebuffer file descriptor."""
+        var_info = FbMem.VarScreenInfo()
+        fcntl.ioctl(fbfid, FbMem.FBIOGET_VSCREENINFO, var_info)
+        return var_info
+
+
+    @staticmethod
+    def _map_fb_memory(fbfid, fix_info):
+        """Map the framebuffer memory."""
+        return mmap.mmap(
+            fbfid,
+            fix_info.smem_len,
+            mmap.MAP_SHARED,
+            mmap.PROT_READ | mmap.PROT_WRITE,
+            offset=0
+        )
+
+class LCD(FbMem):
+    """
+    A convenience wrapper for the FbMem class.
+    Provides drawing functions from the python imaging library (PIL).
+    """
+
+    def __init__(self):
+        FbMem.__init__(self)
+
+        def alignup(n, m):
+            r = n % m
+            if r == 0: return n
+            return n - r + m
+
+        self._img = Image.new("1", (alignup(self.xres, 32), self.yres), "white")
+
+        self.draw = ImageDraw.Draw(self._img)
+
+    @property
+    def xres(self):
+        """
+        Horizontal LCD screen resolution
+        """
+        return self.var_info.xres
+
+    @property
+    def yres(self):
+        """
+        Vertical LCD screen resolution
+        """
+        return self.var_info.yres
+
+    @property
+    def shape(self):
+        """
+        Dimensions of the LCD screen.
+        """
+        return (self.xres, self.yres)
+
+    @property
+    def draw(self):
+        """
+        Returns a handle to PIL.ImageDraw.Draw class associated with LCD.
+        Example::
+            lcd.draw.rectangle((10,10,60,20), fill='black')
+        """
+        return self.draw
+
+    def clear(self):
+        """
+        Clears the LCD screen
+        """
+        self.draw.rectangle(((0,0), self.shape), fill="white")
+
+    def update(self):
+        """
+        Applies pending changes to the LCD.
+        Nothing will be drawn on the screen until this function is called.
+        """
+        self.mmap[:] = self._img.tobytes("raw", "1;IR")
 


### PR DESCRIPTION
`FbMem` provides generic framebuffer info and also maps framebuffer memory. The implementation is adopted from https://github.com/LinkCareServices/cairotft/blob/master/cairotft/linuxfb.py
(also see @dlech's [comment](https://github.com/ev3dev/ev3dev/issues/404#issuecomment-144135010)).

`LCD` is a convenience class that wraps `FbMem` and provides drawing functions from the Python Imaging Library (PIL).