### PR TITLE
Replace pil with Pillow in python package requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     url='https://github.com/rhempel/ev3dev-lang-python',
     include_package_data=True,
     py_modules=['ev3dev'],
-    install_requires=['pil']
+    install_requires=['Pillow']
     )
 


### PR DESCRIPTION
Debian package `python-pil` does install Pillow, the alive fork of dead
PIL project. When, however, `pil` is specified as package dependency in
`setup.py`, and `python-ev3dev` is installed with either
`easy_install python-ev3dev` or `python setup.py install`,
an attempt is made to install the actual PIL from PyPI. This fails on my
host system, and I think is not desired behavior anyway.

Also see ev3dev/ev3dev-lang#113