### PR TITLE
Use packages clause in setup.py instead of py_modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     license='MIT',
     url='https://github.com/rhempel/ev3dev-lang-python',
     include_package_data=True,
-    py_modules=['ev3dev'],
+    packages=['ev3dev'],
     install_requires=['Pillow']
     )
 


### PR DESCRIPTION
Otherwise setup looks for ev3dev.py, does not find it and installs
nothing. Forgot to copy this from @EricPobot's changes.