### PR TITLE
Switch to group-based interface in Leds

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Module interface
     InfraredSensor
     RemoteControl
     Led
+    Leds
     PowerSupply
     Button
     Sound
@@ -107,6 +108,9 @@ Other
 ^^^^^
 
 .. autoclass:: Led
+    :members:
+
+.. autoclass:: Leds
     :members:
 
 .. autoclass:: PowerSupply

--- a/ev3dev/brickpi.py
+++ b/ev3dev/brickpi.py
@@ -50,10 +50,10 @@ class Leds(object):
     blue_one = Led(name='brickpi1:blue:ev3dev')
     blue_two = Led(name='brickpi2:blue:ev3dev')
 
-    BLUE_ONE = (blue_one)
-    BLUE_TWO = (blue_two)
+    BLUE_ONE = (blue_one, )
+    BLUE_TWO = (blue_two, )
 
-    BLUE = (1)
+    BLUE = (1, )
 
     @staticmethod
     def set_color(group, color, pct=1):

--- a/ev3dev/brickpi.py
+++ b/ev3dev/brickpi.py
@@ -50,21 +50,43 @@ class Leds(object):
     blue_one = Led(name='brickpi1:blue:ev3dev')
     blue_two = Led(name='brickpi2:blue:ev3dev')
 
-    @staticmethod
-    def mix_colors(blue):
-        Leds.blue_one.brightness_pct = blue
-        Leds.blue_two.brightness_pct = blue
+    BLUE_ONE = (blue_one)
+    BLUE_TWO = (blue_two)
+
+    BLUE = (1)
 
     @staticmethod
-    def set_blue(pct):
-        Leds.mix_colors(blue=1 * pct)
+    def set_color(group, color, pct=1):
+        """
+        Sets brigthness of leds in the given group to the values specified in
+        color tuple. When percentage is specified, brightness of each led is
+        reduced proportionally.
+
+        Example::
+
+            Leds.set_color(LEFT, AMBER)
+        """
+        for l, v in zip(group, color):
+            l.brightness_pct = v * pct
 
     @staticmethod
-    def blue_on():
-        Leds.set_blue(1)
+    def set(group, **kwargs):
+        """
+        Set attributes for each led in group.
+
+        Example::
+
+            Leds.set(LEFT, brightness_pct=0.5, trigger='timer')
+        """
+        for led in group:
+            for k in kwargs:
+                setattr(led, k, kwargs[k])
 
     @staticmethod
     def all_off():
+        """
+        Turn all leds off
+        """
         Leds.blue_one.brightness = 0
         Leds.blue_two.brightness = 0
 

--- a/ev3dev/ev3.py
+++ b/ev3dev/ev3.py
@@ -52,55 +52,47 @@ class Leds(object):
     green_left = Led(name='ev3-left1:green:ev3dev')
     green_right = Led(name='ev3-right1:green:ev3dev')
 
-    @staticmethod
-    def mix_colors(red, green):
-        Leds.red_left.brightness_pct = red
-        Leds.red_right.brightness_pct = red
-        Leds.green_left.brightness_pct = green
-        Leds.green_right.brightness_pct = green
+    LEFT = (red_left, green_left)
+    RIGHT = (red_right, green_right)
+
+    RED = (1, 0)
+    GREEN = (0, 1)
+    AMBER = (1, 1)
+    ORANGE = (1, 0.5)
+    YELLOW = (0.5, 1)
 
     @staticmethod
-    def set_red(pct):
-        Leds.mix_colors(red=1 * pct, green=0 * pct)
+    def set_color(group, color, pct=1):
+        """
+        Sets brigthness of leds in the given group to the values specified in
+        color tuple. When percentage is specified, brightness of each led is
+        reduced proportionally.
+
+        Example::
+
+            Leds.set_color(LEFT, AMBER)
+        """
+        for l, v in zip(group, color):
+            l.brightness_pct = v * pct
 
     @staticmethod
-    def red_on():
-        Leds.set_red(1)
+    def set(group, **kwargs):
+        """
+        Set attributes for each led in group.
 
-    @staticmethod
-    def set_green(pct):
-        Leds.mix_colors(red=0 * pct, green=1 * pct)
+        Example::
 
-    @staticmethod
-    def green_on():
-        Leds.set_green(1)
-
-    @staticmethod
-    def set_amber(pct):
-        Leds.mix_colors(red=1 * pct, green=1 * pct)
-
-    @staticmethod
-    def amber_on():
-        Leds.set_amber(1)
-
-    @staticmethod
-    def set_orange(pct):
-        Leds.mix_colors(red=1 * pct, green=0.5 * pct)
-
-    @staticmethod
-    def orange_on():
-        Leds.set_orange(1)
-
-    @staticmethod
-    def set_yellow(pct):
-        Leds.mix_colors(red=0.5 * pct, green=1 * pct)
-
-    @staticmethod
-    def yellow_on():
-        Leds.set_yellow(1)
+            Leds.set(LEFT, brightness_pct=0.5, trigger='timer')
+        """
+        for led in group:
+            for k in kwargs:
+                setattr(led, k, kwargs[k])
 
     @staticmethod
     def all_off():
+        """
+        Turn all leds off
+        """
         Leds.red_left.brightness = 0
         Leds.red_right.brightness = 0
         Leds.green_left.brightness = 0

--- a/ev3dev/ev3.py
+++ b/ev3dev/ev3.py
@@ -52,14 +52,14 @@ class Leds(object):
     green_left = Led(name='ev3-left1:green:ev3dev')
     green_right = Led(name='ev3-right1:green:ev3dev')
 
-    LEFT = (red_left, green_left)
-    RIGHT = (red_right, green_right)
+    LEFT = (red_left, green_left, )
+    RIGHT = (red_right, green_right, )
 
-    RED = (1, 0)
-    GREEN = (0, 1)
-    AMBER = (1, 1)
-    ORANGE = (1, 0.5)
-    YELLOW = (0.5, 1)
+    RED = (1, 0, )
+    GREEN = (0, 1, )
+    AMBER = (1, 1, )
+    ORANGE = (1, 0.5, )
+    YELLOW = (0.5, 1, )
 
     @staticmethod
     def set_color(group, color, pct=1):

--- a/templates/led-colors.liquid
+++ b/templates/led-colors.liquid
@@ -2,34 +2,50 @@
     assign instanceName = instance.name | downcase | underscore_spaces %}
     {{instanceName}} = Led(name='{{instance.systemName}}'){%
 endfor %}
-
-    @staticmethod
-    def mix_colors({%
-for group in currentClass.groups%}{{ group.name | downcase | underscore_spaces }}{%
-    unless forloop.last %}, {% endunless %}{%
-endfor %}):{%
-for group in currentClass.groups %}{%
-    assign groupName = group.name | downcase | underscore_spaces %}{%
-    for instance in group.entries %}{%
-        assign instanceName = instance | downcase | underscore_spaces %}
-        Leds.{{instanceName}}.brightness_pct = {{groupName}}{%
-    endfor %}{%
+{% for group in currentClass.groups %}{%
+    assign groupName = group.name | upcase | underscore_spaces %}
+    {{ groupName }} = ({% for e in group.entries %}{%
+        assign instance = e | downcase | underscore_spaces
+%}{{ instance }}{% unless forloop.last %}, {% endunless %}{%
+    endfor %}){%
 endfor %}
 {% for color in currentClass.colors %}{%
-    assign colorName = color.name | downcase | underscore_spaces %}
-    @staticmethod
-    def set_{{ colorName }}(pct):
-        Leds.mix_colors({%
-    for group in color.groups %}{{ group.name | downcase | underscore_spaces }}={{ group.value }} * pct{%
-        unless forloop.last %}, {% endunless %}{%
-    endfor %})
+    assign colorName = color.name | upcase | underscore_spaces %}
+    {{ colorName }} = ({% for v in color.value %}{{ v }}{% unless forloop.last %}, {% endunless %}{%endfor %}){%
+endfor %}
 
     @staticmethod
-    def {{ colorName }}_on():
-        Leds.set_{{ colorName }}(1)
-{% endfor %}
+    def set_color(group, color, pct=1):
+        """
+        Sets brigthness of leds in the given group to the values specified in
+        color tuple. When percentage is specified, brightness of each led is
+        reduced proportionally.
+
+        Example::
+
+            Leds.set_color(LEFT, AMBER)
+        """
+        for l, v in zip(group, color):
+            l.brightness_pct = v * pct
+
     @staticmethod
-    def all_off():{%
+    def set(group, **kwargs):
+        """
+        Set attributes for each led in group.
+
+        Example::
+
+            Leds.set(LEFT, brightness_pct=0.5, trigger='timer')
+        """
+        for led in group:
+            for k in kwargs:
+                setattr(led, k, kwargs[k])
+
+    @staticmethod
+    def all_off():
+        """
+        Turn all leds off
+        """{%
 for instance in currentClass.instances %}{%
     assign instanceName = instance.name | downcase | underscore_spaces %}
         Leds.{{instanceName}}.brightness = 0{%

--- a/templates/led-colors.liquid
+++ b/templates/led-colors.liquid
@@ -6,12 +6,12 @@ endfor %}
     assign groupName = group.name | upcase | underscore_spaces %}
     {{ groupName }} = ({% for e in group.entries %}{%
         assign instance = e | downcase | underscore_spaces
-%}{{ instance }}{% unless forloop.last %}, {% endunless %}{%
+%}{{ instance }}, {%
     endfor %}){%
 endfor %}
 {% for color in currentClass.colors %}{%
     assign colorName = color.name | upcase | underscore_spaces %}
-    {{ colorName }} = ({% for v in color.value %}{{ v }}{% unless forloop.last %}, {% endunless %}{%endfor %}){%
+    {{ colorName }} = ({% for v in color.value %}{{ v }}, {%endfor %}){%
 endfor %}
 
     @staticmethod


### PR DESCRIPTION
This is based on discussion at https://github.com/rhempel/ev3dev-lang-python/issues/37#issuecomment-153442761.

This introduces concepts of led groups (see also ev3dev/ev3dev#412) and colors into `Leds` class. The led groups may be operated as in:
```py
# Set group color:
Leds.set_color(Leds.LEFT, Leds.AMBER)
Leds.set_color(Leds.RIGHT, (1.0, 0.75))

# Batch set arbitrary led properties in group:
Leds.set(Leds.LEFT, trigger='timer', brightness_pct=0.5)
```

I hope this is close to what @EricPobot had in mind.

This is accompanied by rhempel/ev3dev-lang@28361dad5e4f33749ee76634eeedfc1b972b6507