### PR TITLE
Fix a bug in Sound.tone translation to beep

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -2349,7 +2349,7 @@ class Sound:
                 args = '-n '
                 if frequency is not None: args += '-f %s ' % frequency
                 if duration  is not None: args += '-l %s ' % duration
-                if delay     is not None: args += '-d %s ' % delay
+                if delay     is not None: args += '-D %s ' % delay
 
                 return args
 


### PR DESCRIPTION
Delay argument was incorrectly translated to `-d` command line parameter for `/usr/bin/beep`. `-D` is the correct option for delay.