### PR TITLE
Use os.stat instead of os.access

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -36,6 +36,7 @@ import array
 import mmap
 import ctypes
 import re
+import stat
 from os.path import abspath
 from PIL import Image, ImageDraw
 from struct import pack, unpack
@@ -58,8 +59,10 @@ class FileCache(object):
         """Manages the file handle cache and opening the files in the correct mode"""
 
         if path not in self._cache:
-            r_ok = os.access(path, os.R_OK)
-            w_ok = os.access(path, os.W_OK)
+            mode = stat.S_IMODE(os.stat(path)[stat.ST_MODE])
+
+            r_ok = mode & stat.S_IRGRP
+            w_ok = mode & stat.S_IWGRP
 
             if r_ok and w_ok:
                 mode = 'a+'


### PR DESCRIPTION
This gives true file permissions irregardless of the current user.

Tested both for normal user and root.

Fixes #84