### PR TITLE
Add remote control demo

### DIFF
--- a/demo/auto-drive.py
+++ b/demo/auto-drive.py
@@ -37,7 +37,7 @@ from random import choice, randint
 from ev3dev.auto import *
 
 # Connect two large motors on output ports B and C:
-motors = [LargeMotor(port) for port in (OUTPUT_C, OUTPUT_B)];
+motors = [LargeMotor(port) for port in (OUTPUT_B, OUTPUT_C)]
 
 # Every device in ev3dev has `connected` property. Use it to check that the
 # device has actually been connected.
@@ -45,8 +45,8 @@ assert all([m.connected for m in motors]), \
     "Two large motors should be connected to ports B and C"
 
 # Connect infrared and touch sensors.
-ir  = InfraredSensor(); assert ir.connected
-ts  = TouchSensor();    assert ts.connected
+ir = InfraredSensor(); assert ir.connected
+ts = TouchSensor();    assert ts.connected
 
 # Put the infrared sensor into proximity mode.
 ir.mode = 'IR-PROX'

--- a/demo/remote-control.py
+++ b/demo/remote-control.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015 Denis Demidov <dennis.demidov@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# -----------------------------------------------------------------------------
+
+# This demo shows how to remote control an Explor3r robot with touch sensor
+# attachment.
+#
+# Red buttons control left motor, blue buttons control right motor.
+# Leds are used to indicate movement direction.
+# Whenever an obstacle is bumped, robot backs away and apologises.
+
+from time import sleep
+from ev3dev.auto import *
+
+# Connect two large motors on output ports B and C
+lmotor, rmotor = [LargeMotor(port) for port in (OUTPUT_B, OUTPUT_C)]
+
+# Check that the motors are actually connected
+assert lmotor.connected
+assert rmotor.connected
+
+# Connect touch sensor and remote control
+ts = TouchSensor();   assert ts.connected
+rc = RemoteControl(); assert rc.connected
+
+# Initialize button handler
+button = Button()
+
+# Turn leds off
+Leds.all_off()
+
+def roll(motor, led_group, direction):
+    """
+    Generate remote control event handler. It rolls given motor into given
+    direction (1 for forward, -1 for backward). When motor rolls forward, the
+    given led group flashes green, when backward -- red. When motor stops, the
+    leds are turned off.
+
+    The on_press function has signature required by RemoteControl class.
+    It takes boolean state parameter; True when button is pressed, False
+    otherwise.
+    """
+    def on_press(state):
+        if state:
+            # Roll when button is pressed
+            motor.run_forever(duty_cycle_sp=90*direction)
+            Leds.set_color(led_group, direction > 0 and Leds.GREEN or Leds.RED)
+        else:
+            # Stop otherwise
+            motor.stop(stop_command='brake')
+            Leds.set(led_group, brightness_pct=0)
+
+    return on_press
+
+# Assign event handler to each of the remote buttons
+rc.on_red_up    = roll(lmotor, Leds.LEFT,   1)
+rc.on_red_down  = roll(lmotor, Leds.LEFT,  -1)
+rc.on_blue_up   = roll(rmotor, Leds.RIGHT,  1)
+rc.on_blue_down = roll(rmotor, Leds.RIGHT, -1)
+
+# Enter event processing loop
+while not button.any():
+    rc.process()
+
+    # Backup when bumped an obstacle
+    if ts.value():
+        Sound.speak('Oops, excuse me!')
+
+        for motor in (lmotor, rmotor):
+            motor.stop(stop_command='brake')
+
+        # Turn red lights on
+        for led in (Leds.LEFT, Leds.RIGHT):
+            Leds.set_color(led, Leds.RED)
+
+        # Run both motors backwards for 0.5 seconds
+        for motor in (lmotor, rmotor):
+            motor.run_timed(duty_cycle_sp=-90, time_sp=500)
+
+        # Wait 0.5 seconds while motors are rolling
+        sleep(0.5)
+
+        Leds.all_off()
+
+    sleep(0.01)

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -1880,6 +1880,10 @@ class RemoteControl(ButtonBase):
             self._sensor.mode = 'IR-REMOTE'
 
     @property
+    def connected(self):
+        return self._sensor.connected
+
+    @property
     def buttons_pressed(self):
         """
         Returns list of currently pressed buttons.


### PR DESCRIPTION
This adds a remote control demo. While implementing this I noticed that we miss `RemoteControl.connected` property. The first commit adds that. This should not affect existing code.