### PR TITLE
Rename EV3 leds after the latest kernel update

### DIFF
--- a/ev3dev/ev3.py
+++ b/ev3dev/ev3.py
@@ -47,10 +47,10 @@ class Leds(object):
 
 # ~autogen led-colors platforms.ev3.led>currentClass
 
-    red_left = Led(name='ev3-left0:red:ev3dev')
-    red_right = Led(name='ev3-right0:red:ev3dev')
-    green_left = Led(name='ev3-left1:green:ev3dev')
-    green_right = Led(name='ev3-right1:green:ev3dev')
+    red_left = Led(name='ev3:left:red:ev3dev')
+    red_right = Led(name='ev3:right:red:ev3dev')
+    green_left = Led(name='ev3:left:green:ev3dev')
+    green_right = Led(name='ev3:right:green:ev3dev')
 
     LEFT = ( red_left, green_left, )
     RIGHT = ( red_right, green_right, )


### PR DESCRIPTION
See http://www.ev3dev.org/news/2015/11/09/Kernel-Release-Cycle-8.

Depends on rhempel/ev3dev-lang#6