### PR TITLE
Implement device enumeration functions

### DIFF
--- a/ev3dev/brickpi.py
+++ b/ev3dev/brickpi.py
@@ -47,8 +47,8 @@ class Leds(object):
 
 # ~autogen led-colors platforms.brickpi.led>currentClass
 
-    blue_one = Led(name='brickpi1:blue:ev3dev')
-    blue_two = Led(name='brickpi2:blue:ev3dev')
+    blue_one = Led(name_pattern='brickpi1:blue:ev3dev')
+    blue_two = Led(name_pattern='brickpi2:blue:ev3dev')
 
     BLUE_ONE = ( blue_one, )
     BLUE_TWO = ( blue_two, )

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -104,14 +104,14 @@ class Device(object):
 
     _DEVICE_INDEX = re.compile(r'^.*(?P<idx>\d+)$')
 
-    def __init__(self, class_name, name='*', **kwargs):
+    def __init__(self, class_name, name_pattern='*', **kwargs):
         """Spin through the Linux sysfs class for the device type and find
-        a device that matches the provided name and attributes (if any).
+        a device that matches the provided name pattern and attributes (if any).
 
         Parameters:
             class_name: class name of the device, a subdirectory of /sys/class.
                 For example, 'tacho-motor'.
-            name: pattern that device name should match.
+            name_pattern: pattern that device name should match.
                 For example, 'sensor*' or 'motor*'. Default value: '*'.
             keyword arguments: used for matching the corresponding device
                 attributes. For example, port_name='outA', or
@@ -131,7 +131,7 @@ class Device(object):
         self._attribute_cache = FileCache()
 
         for file in os.listdir(classpath):
-            if fnmatch.fnmatch(file, name):
+            if fnmatch.fnmatch(file, name_pattern):
                 self._path = abspath(classpath + '/' + file)
 
                 # See if requested attributes match:
@@ -212,10 +212,10 @@ class Motor(Device):
     SYSTEM_CLASS_NAME = 'tacho-motor'
     SYSTEM_DEVICE_NAME_CONVENTION = 'motor*'
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
 
 
 # ~autogen
@@ -693,10 +693,10 @@ class LargeMotor(Motor):
     SYSTEM_CLASS_NAME = Motor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Motor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['lego-ev3-l-motor'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-l-motor'], **kwargs)
 
 
 # ~autogen
@@ -711,10 +711,10 @@ class MediumMotor(Motor):
     SYSTEM_CLASS_NAME = Motor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Motor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['lego-ev3-m-motor'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-m-motor'], **kwargs)
 
 
 # ~autogen
@@ -731,10 +731,10 @@ class DcMotor(Device):
     SYSTEM_CLASS_NAME = 'dc-motor'
     SYSTEM_DEVICE_NAME_CONVENTION = 'motor*'
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
 
 
 # ~autogen
@@ -966,10 +966,10 @@ class ServoMotor(Device):
     SYSTEM_CLASS_NAME = 'servo-motor'
     SYSTEM_DEVICE_NAME_CONVENTION = 'motor*'
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
 
 
 # ~autogen
@@ -1166,10 +1166,10 @@ class Sensor(Device):
     SYSTEM_CLASS_NAME = 'lego-sensor'
     SYSTEM_DEVICE_NAME_CONVENTION = 'sensor*'
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
 
 
 # ~autogen
@@ -1332,10 +1332,10 @@ class I2cSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['nxt-i2c-sensor'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['nxt-i2c-sensor'], **kwargs)
 
 
 # ~autogen
@@ -1376,10 +1376,10 @@ class ColorSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['lego-ev3-color'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-color'], **kwargs)
 
 
 # ~autogen
@@ -1413,10 +1413,10 @@ class UltrasonicSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['lego-ev3-us', 'lego-nxt-us'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-us', 'lego-nxt-us'], **kwargs)
 
 
 # ~autogen
@@ -1454,10 +1454,10 @@ class GyroSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['lego-ev3-gyro'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-gyro'], **kwargs)
 
 
 # ~autogen
@@ -1491,10 +1491,10 @@ class InfraredSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['lego-ev3-ir'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-ir'], **kwargs)
 
 
 # ~autogen
@@ -1528,10 +1528,10 @@ class SoundSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['lego-nxt-sound'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-nxt-sound'], **kwargs)
 
 
 # ~autogen
@@ -1556,10 +1556,10 @@ class LightSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['lego-nxt-light'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-nxt-light'], **kwargs)
 
 
 # ~autogen
@@ -1584,10 +1584,10 @@ class TouchSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, driver_name=['lego-ev3-touch', 'lego-nxt-touch'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-touch', 'lego-nxt-touch'], **kwargs)
 
 
 # ~autogen
@@ -1604,10 +1604,10 @@ class Led(Device):
     SYSTEM_CLASS_NAME = 'leds'
     SYSTEM_DEVICE_NAME_CONVENTION = '*'
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
 
 
 # ~autogen
@@ -1903,10 +1903,10 @@ class PowerSupply(Device):
     SYSTEM_CLASS_NAME = 'power_supply'
     SYSTEM_DEVICE_NAME_CONVENTION = '*'
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
 
 
 # ~autogen
@@ -2003,10 +2003,10 @@ class LegoPort(Device):
     SYSTEM_CLASS_NAME = 'lego_port'
     SYSTEM_DEVICE_NAME_CONVENTION = '*'
 
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
 
 
 # ~autogen

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -272,10 +272,10 @@ class Motor(Device):
     SYSTEM_CLASS_NAME = 'tacho-motor'
     SYSTEM_DEVICE_NAME_CONVENTION = 'motor*'
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, **kwargs)
 
 
 # ~autogen
@@ -753,10 +753,10 @@ class LargeMotor(Motor):
     SYSTEM_CLASS_NAME = Motor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Motor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-l-motor'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['lego-ev3-l-motor'], **kwargs)
 
 
 # ~autogen
@@ -771,10 +771,10 @@ class MediumMotor(Motor):
     SYSTEM_CLASS_NAME = Motor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Motor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-m-motor'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['lego-ev3-m-motor'], **kwargs)
 
 
 # ~autogen
@@ -791,10 +791,10 @@ class DcMotor(Device):
     SYSTEM_CLASS_NAME = 'dc-motor'
     SYSTEM_DEVICE_NAME_CONVENTION = 'motor*'
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, **kwargs)
 
 
 # ~autogen
@@ -1026,10 +1026,10 @@ class ServoMotor(Device):
     SYSTEM_CLASS_NAME = 'servo-motor'
     SYSTEM_DEVICE_NAME_CONVENTION = 'motor*'
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, **kwargs)
 
 
 # ~autogen
@@ -1226,10 +1226,10 @@ class Sensor(Device):
     SYSTEM_CLASS_NAME = 'lego-sensor'
     SYSTEM_DEVICE_NAME_CONVENTION = 'sensor*'
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, **kwargs)
 
 
 # ~autogen
@@ -1392,10 +1392,10 @@ class I2cSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['nxt-i2c-sensor'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['nxt-i2c-sensor'], **kwargs)
 
 
 # ~autogen
@@ -1436,10 +1436,10 @@ class ColorSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-color'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['lego-ev3-color'], **kwargs)
 
 
 # ~autogen
@@ -1473,10 +1473,10 @@ class UltrasonicSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-us', 'lego-nxt-us'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['lego-ev3-us', 'lego-nxt-us'], **kwargs)
 
 
 # ~autogen
@@ -1514,10 +1514,10 @@ class GyroSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-gyro'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['lego-ev3-gyro'], **kwargs)
 
 
 # ~autogen
@@ -1551,10 +1551,10 @@ class InfraredSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-ir'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['lego-ev3-ir'], **kwargs)
 
 
 # ~autogen
@@ -1588,10 +1588,10 @@ class SoundSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-nxt-sound'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['lego-nxt-sound'], **kwargs)
 
 
 # ~autogen
@@ -1616,10 +1616,10 @@ class LightSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-nxt-light'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['lego-nxt-light'], **kwargs)
 
 
 # ~autogen
@@ -1644,10 +1644,10 @@ class TouchSensor(Sensor):
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, driver_name=['lego-ev3-touch', 'lego-nxt-touch'], **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, driver_name=['lego-ev3-touch', 'lego-nxt-touch'], **kwargs)
 
 
 # ~autogen
@@ -1664,10 +1664,10 @@ class Led(Device):
     SYSTEM_CLASS_NAME = 'leds'
     SYSTEM_DEVICE_NAME_CONVENTION = '*'
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, **kwargs)
 
 
 # ~autogen
@@ -1963,10 +1963,10 @@ class PowerSupply(Device):
     SYSTEM_CLASS_NAME = 'power_supply'
     SYSTEM_DEVICE_NAME_CONVENTION = '*'
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, **kwargs)
 
 
 # ~autogen
@@ -2063,10 +2063,10 @@ class LegoPort(Device):
     SYSTEM_CLASS_NAME = 'lego_port'
     SYSTEM_DEVICE_NAME_CONVENTION = '*'
 
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact, **kwargs)
 
 
 # ~autogen

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -742,6 +742,27 @@ class Motor(Device):
 
 
 # ~autogen
+
+def list_motors(name_pattern=Motor.SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    """
+    This is a generator function that enumerates all tacho motors that match
+    the provided arguments.
+
+    Parameters:
+	name_pattern: pattern that device name should match.
+	    For example, 'sensor*' or 'motor*'. Default value: '*'.
+	keyword arguments: used for matching the corresponding device
+	    attributes. For example, driver_name='lego-ev3-l-motor', or
+	    port_name=['outB', 'outC']. When argument value
+	    is a list, then a match against any entry of the list is
+	    enough.
+    """
+    classpath = abspath(Device.DEVICE_ROOT_PATH + '/' + Motor.SYSTEM_CLASS_NAME)
+
+    return (Motor(name_pattern=name, name_exact=True)
+            for name in list_device_names(classpath, name_pattern, **kwargs))
+
+
 # ~autogen generic-class classes.largeMotor>currentClass
 
 class LargeMotor(Motor):

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -95,6 +95,41 @@ class FileCache(object):
 
 
 # -----------------------------------------------------------------------------
+def list_device_names(class_path, name_pattern, **kwargs):
+    """
+    This is a generator function that lists names of all devices matching the
+    provided parameters.
+
+    Parameters:
+	class_path: class path of the device, a subdirectory of /sys/class.
+	    For example, '/sys/class/tacho-motor'.
+	name_pattern: pattern that device name should match.
+	    For example, 'sensor*' or 'motor*'. Default value: '*'.
+	keyword arguments: used for matching the corresponding device
+	    attributes. For example, port_name='outA', or
+	    driver_name=['lego-ev3-us', 'lego-nxt-us']. When argument value
+	    is a list, then a match against any entry of the list is
+	    enough.
+    """
+    def matches(attribute, pattern):
+        try:
+            with open(attribute) as f:
+                value = f.read().strip()
+        except:
+            return False
+
+        if isinstance(pattern, list):
+            return any([value.find(p) >= 0 for p in pattern])
+        else:
+            return value.find(pattern) >= 0
+
+    for f in os.listdir(class_path):
+        if fnmatch.fnmatch(f, name_pattern):
+            path = class_path + '/' + f
+            if all([matches(path + '/' + k, kwargs[k]) for k in kwargs]):
+                yield f
+
+# -----------------------------------------------------------------------------
 # Define the base class from which all other ev3dev classes are defined.
 
 class Device(object):

--- a/ev3dev/ev3.py
+++ b/ev3dev/ev3.py
@@ -47,10 +47,10 @@ class Leds(object):
 
 # ~autogen led-colors platforms.ev3.led>currentClass
 
-    red_left = Led(name='ev3:left:red:ev3dev')
-    red_right = Led(name='ev3:right:red:ev3dev')
-    green_left = Led(name='ev3:left:green:ev3dev')
-    green_right = Led(name='ev3:right:green:ev3dev')
+    red_left = Led(name_pattern='ev3:left:red:ev3dev')
+    red_right = Led(name_pattern='ev3:right:red:ev3dev')
+    green_left = Led(name_pattern='ev3:left:green:ev3dev')
+    green_right = Led(name_pattern='ev3:right:green:ev3dev')
 
     LEFT = ( red_left, green_left, )
     RIGHT = ( red_right, green_right, )

--- a/templates/generic-class.liquid
+++ b/templates/generic-class.liquid
@@ -34,8 +34,8 @@ endfor %}
     SYSTEM_CLASS_NAME = '{{ currentClass.systemClassName }}'
     SYSTEM_DEVICE_NAME_CONVENTION = '{{ device_name_convention }}'
 {% endif %}
-    def __init__(self, port=None, name=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name,{{ driver_name }} **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern,{{ driver_name }} **kwargs)
 

--- a/templates/generic-class.liquid
+++ b/templates/generic-class.liquid
@@ -34,8 +34,8 @@ endfor %}
     SYSTEM_CLASS_NAME = '{{ currentClass.systemClassName }}'
     SYSTEM_DEVICE_NAME_CONVENTION = '{{ device_name_convention }}'
 {% endif %}
-    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
+    def __init__(self, port=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         if port is not None:
             kwargs['port_name'] = port
-        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern,{{ driver_name }} **kwargs)
+        Device.__init__(self, self.SYSTEM_CLASS_NAME, name_pattern, name_exact,{{ driver_name }} **kwargs)
 

--- a/templates/led-colors.liquid
+++ b/templates/led-colors.liquid
@@ -1,6 +1,6 @@
 {% for instance in currentClass.instances %}{%
     assign instanceName = instance.name | downcase | underscore_spaces %}
-    {{instanceName}} = Led(name='{{instance.systemName}}'){%
+    {{instanceName}} = Led(name_pattern='{{instance.systemName}}'){%
 endfor %}
 {% for group in currentClass.groups %}{%
     assign groupName = group.name | upcase | underscore_spaces %}{%


### PR DESCRIPTION
This adds ability to enumerate devices available on the system. This is a multi-step PR, with steps being:

* Rename `name` argument of Device constructor to `name_pattern`. Some devices in `sys/class` have `name` attribute (e.g. `/sys/class/input*/name`). Having a positional argument `name` would
prohibit filtering such devices by `name` attribute in kwargs (because positional argument `name` would clash with keyword argument `name`).
* Implement `list_device_names` generator function. The function takes same arguments as `Device` constructor and lists all device names that match the provided arguments. Example:
```py
>>> [n for n in list_device_names('/sys/class/tacho-motor', 'motor*')]
['motor0', 'motor1']
```
* Implement `list_devices` generator function. The function takes same argument as `Device` class and enumerates all devices present in the system that match the provided arguments. In order to implement the function, optional argument `name_exact` was added to `Device` constructor. When `name_exact=True`, the constructor assumes that `name_pattern` argument contains exact device name and constructs the `Device` directly, without any checks. Example:
```py
[m.get_attr_string('port_name') for m in list_devices('tacho-motor', 'motor*')]
['outB', 'outC']
```
* Implement list_motors generator function. Enumerates all tacho motors present in the system. Example:
```py
[m.port_name for m in list_motors()]
['outB', 'outC']
```

More generator functions may be easily added later for different class types.