### PR TITLE
Switch to decentralized model

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ev3dev-lang"]
+	path = ev3dev-lang
+	url = https://github.com/ev3dev/ev3dev-lang.git

--- a/autogen-config.json
+++ b/autogen-config.json
@@ -1,0 +1,9 @@
+{
+    "files": [
+        "ev3dev/core.py",
+        "ev3dev/ev3.py",
+        "ev3dev/brickpi.py",
+        "spec_version.py"
+    ],
+    "templateDir": "templates/"
+}


### PR DESCRIPTION
See ev3dev/ev3dev-lang#142

This creates a submodule pointing to decentralized branch of ev3dev/ev3dev-lang, and adds the required `autogen-config.json` file. When this is merged, autogen may be executed as `./ev3dev/exec-autogen.js`.

Also, I am not sure which branch to create pull requests against now. It looks like develop suffered from recent merge disasters. Should it be just hard reset to master?