### PR TITLE
25% read/write speed increase

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -197,11 +197,11 @@ class Device(object):
 
     def _get_attribute(self, attribute):
         """Device attribute getter"""
-        return self._attribute_cache.read(abspath(self._path + '/' + attribute))
+        return self._attribute_cache.read(self._path + '/' + attribute)
 
     def _set_attribute(self, attribute, value):
         """Device attribute setter"""
-        self._attribute_cache.write(abspath(self._path + '/' + attribute), value)
+        self._attribute_cache.write(self._path + '/' + attribute, value)
 
     def get_attr_int(self, attribute):
         return int(self._get_attribute(attribute))


### PR DESCRIPTION
Removing the abspath call increases r/w speed by 25% on my ev3