### PR TITLE
Expose Screen._img as Screen.image.

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -2537,6 +2537,18 @@ class Screen(FbMem):
         """
         return self._draw
 
+    @property
+    def image(self):
+        """
+        Returns a handle to PIL.Image class that is backing the screen. This can
+        be accessed for blitting images to the screen.
+
+        Example::
+
+            screen.image.paste(picture, (0, 0))
+        """
+        return self._img
+
     def clear(self):
         """
         Clears the screen


### PR DESCRIPTION
This is useful for blitting images to the screen.

Fixes #142