### PR TITLE
Fix error when a device class dir doesn't exist

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -57,6 +57,10 @@ OUTPUT_AUTO = ''
 
 # -----------------------------------------------------------------------------
 def list_device_names(class_path, name_pattern, **kwargs):
+
+    if not os.path.isdir(class_path):
+        return
+    
     """
     This is a generator function that lists names of all devices matching the
     provided parameters.

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -36,6 +36,9 @@ class TestAPI(unittest.TestCase):
         d = ev3.Device('lego-sensor', 'sensor*')
         self.assertTrue(d.connected)
 
+        d = ev3.Device('this-does-not-exist')
+        self.assertFalse(d.connected)
+
     def test_medium_motor(self):
         def dummy(self):
             pass

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from populate_arena import populate_arena
 from clean_arena    import clean_arena
 
-import ev3dev.ev3 as ev3
+import ev3dev.core as ev3
 
 ev3.Device.DEVICE_ROOT_PATH = os.path.join(FAKE_SYS, 'arena')
 


### PR DESCRIPTION
If no devices of a given type have been plugged in, the class dir doesn't exist, so `list_device_names` would throw an error while trying to enumerate the folder. This fixes that issue by explicitly checking for the directory first.

I also switched the import to not throw an error in tests when initializing EV3-specific functions.