### PR TITLE
Update changelog for 0.7.0 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,28 @@
 python-ev3dev (0.7.0) stable; urgency=medium
 
-  * Support "-13-ev3dev" and newer kernels. 
+  [Denis Demidov]
+  * Support "-13-ev3dev" and newer kernels.
+  * Rename FirgelliL1250Motor and FirgelliL12100Motor to ActuonixL1250Motor
+    and ActuonixL12100Motor.
+  * Allow passing espeak options to Sound.speak
+  * Make sure that device classes connect to devices of the right
+    type (driver name)
+
+  [Daniel Walton]
+  * Add "__version__" property.
   * Add ev3dev/helper.py with classes for Tanks, Motors, Web UI, etc. 
   * Add ev3dev/GyroBalancer.py for robots that use a gyroscope.
-  * Fix port names on BrickPi.
-  * Fix bad division logic in display classes.
-  * Fix fatal error when a requested sysfs device class hasn't been populated yet.
-  * Add "__version__" property.
 
- -- Kaelin Laundry <wasabifan@outlook.com>  Sat, 24 Sep 2016 13:28:48 -0800
+  [Donald Webster]
+  * Fix port names on BrickPi.
+
+  [Frank Busse]
+  * Fix bad division logic in display classes.
+
+  [Kaelin Laundry]
+  * Fix fatal error when a requested sysfs device class hasn't been populated yet.
+
+ -- Kaelin Laundry <wasabifan@outlook.com>  Sat, 25 Sep 2016 10:35:00 -0800
 
 python-ev3dev (0.7.0~rc1) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+python-ev3dev (0.7.0) stable; urgency=medium
+
+  * Support "-13-ev3dev" and newer kernels. 
+  * Add ev3dev/helper.py with classes for Tanks, Motors, Web UI, etc. 
+  * Add ev3dev/GyroBalancer.py for robots that use a gyroscope.
+  * Fix port names on BrickPi.
+  * Fix bad division logic in display classes.
+  * Fix fatal error when a requested sysfs device class hasn't been populated yet.
+  * Add "__version__" property.
+
+ -- Kaelin Laundry <wasabifan@outlook.com>  Sat, 24 Sep 2016 13:28:48 -0800
+
 python-ev3dev (0.7.0~rc1) stable; urgency=medium
 
   * Drop python 2.x support.


### PR DESCRIPTION
Updated version of #211 with some added items and its own entry. I decided to put my name on the release, based on what I've read about Debian packaging procedures; if that's not right, I can change the name.

Note that these changes are a delta from the RC release; is that the correct thing to do? Or should it be relative to the last stable release (0.6.0)?

The list was based off of this diff: https://github.com/rhempel/ev3dev-lang-python/compare/fb3cdbc...develop