### PR TITLE
Re-enabling python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+- 2.7
 - 3.4
 sudo: false
 install:

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -30,13 +30,6 @@
 
 # -----------------------------------------------------------------------------
 
-import sys
-
-if sys.version_info < (3,4):
-    raise SystemError('Must be using Python 3.4 or higher')
-
-# -----------------------------------------------------------------------------
-
 import os
 import io
 import fnmatch


### PR DESCRIPTION
Also enable python 2.7 in Travis build matrix

python-ev3dev is still installed in the latest nightly builds, because its a dependency of openroberta. But the version installed (0.6.0) is incompatible with the kernel. It turns out nothing in the library code prevents us from supporting python2, so this removes import time check for python version.

All tests are able to pass in python2 without any other changes. Also tested with [ev3rstorm](https://gist.github.com/ddemidov/fc6987229e8f846dbf157f6f063aac26) demo example; it works in both python versions.

openroberta will still need to be updated to the latest API though (pinging @ensonic).

Also there need to be some changes to debian packaging (pinging @dlech).