### PR TITLE
Preparing debian release for 0.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ __pycache__
 dist
 *.egg-info
 RELEASE-VERSION
+ev3dev/version.py
 build

--- a/debian/changelog
+++ b/debian/changelog
@@ -22,9 +22,10 @@ python-ev3dev (0.7.0) stable; urgency=medium
   * Fix bad division logic in display classes.
 
   [Kaelin Laundry]
-  * Fix fatal error when a requested sysfs device class hasn't been populated yet.
+  * Fix fatal error when a requested sysfs device class hasn't been
+    populated yet.
 
- -- Kaelin Laundry <wasabifan@outlook.com>  Sat, 25 Sep 2016 10:35:00 -0800
+ -- Kaelin Laundry <wasabifan@outlook.com>  Sun, 25 Sep 2016 10:35:00 -0800
 
 python-ev3dev (0.7.0~rc1) stable; urgency=medium
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,9 +5,13 @@ Copyright: 2016 Ralph Hempel <rhempel@hempeldesigngroup.com>
 Files: *
 License: MIT
 Copyright: 2016 Ralph Hempel <rhempel@hempeldesigngroup.com>
-Copyright: 2015 Denis Demidov <dennis.demidov@gmail.com>
+Copyright: 2015-2016 Denis Demidov <dennis.demidov@gmail.com>
 Copyright: 2015 Eric Pascual <eric@pobot.org>
 Copyright: 2015 Anton Vanhoucke <antonvh@gmail.com>
+Copyright: 2016 Kaelin Laundry <wasabifan@outlook.com>
+Copyright: 2016 Daniel Walton <dwalton76@gmail.com>
+Copyright: 2016 Donald Webster <fryfrog@gmail.com>
+Copyright: 2016 Frank Busse <bb0xfb@gmail.com>
 
 License: MIT
  Permission is hereby granted, free of charge, to any person obtaining a

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -61,15 +61,12 @@ except ImportError:
 INPUT_AUTO = ''
 OUTPUT_AUTO = ''
 
-# Keep the __version__ in sync with the package version in debian/changelog
-__version__ = '0.7.0'
-
 # -----------------------------------------------------------------------------
 def list_device_names(class_path, name_pattern, **kwargs):
 
     if not os.path.isdir(class_path):
         return
-    
+
     """
     This is a generator function that lists names of all devices matching the
     provided parameters.
@@ -174,7 +171,7 @@ class Device(object):
         mode = stat.S_IMODE(os.stat(path)[stat.ST_MODE])
         r_ok = mode & stat.S_IRGRP
         w_ok = mode & stat.S_IWGRP
-            
+
         if r_ok and w_ok:
             mode = 'r+'
         elif w_ok:
@@ -1420,7 +1417,7 @@ class Sensor(Device):
 # ~autogen
 
         self._value = [None,None,None,None,None,None,None,None]
-        
+
         self._bin_data_format = None
         self._bin_data = None
 

--- a/git_version.py
+++ b/git_version.py
@@ -40,9 +40,8 @@ def read_release_version():
 
 
 def write_release_version(version):
-    f = open("RELEASE-VERSION", "w")
-    f.write("%s\n" % version)
-    f.close()
+    with open("RELEASE-VERSION", "w") as f:
+        f.write("%s\n" % version)
 
 
 def pep386adapt(version):
@@ -77,6 +76,10 @@ def git_version(abbrev=4):
     # RELEASE-VERSION file, update the file to be current.
     if version != release_version:
         write_release_version(version)
+
+    # Update the ev3dev/__version__.py
+    with open('ev3dev/version.py', 'w') as f:
+        f.write("__version__ = '{}'".format(version))
 
     # Finally, return the current version.
     return version


### PR DESCRIPTION
Summary of changes:

1. Update copyright information in debian/copyright (see https://github.com/rhempel/ev3dev-lang-python/issues/207#issuecomment-250687801)
2. Fix lintian warnings (a line too long, and wrong weekday)
3. Get rid of hard-coded `__version__` in `ev3dev/core.py`, and replace it with auto-generated `ev3dev/version.py`.