### PR TITLE
[breaking] Special properties

### DIFF
--- a/demo/EV3RSTORM/ev3rstorm.py
+++ b/demo/EV3RSTORM/ev3rstorm.py
@@ -146,7 +146,7 @@ class ev3rstorm:
 
         # Now that the event handlers are assigned,
         # lets enter the processing loop:
-        while not self.ts.is_pressed():
+        while not self.ts.is_pressed:
             rc1.process()
             rc2.process()
             time.sleep(0.1)

--- a/demo/EXPLOR3R/auto-drive.py
+++ b/demo/EXPLOR3R/auto-drive.py
@@ -48,9 +48,6 @@ assert all([m.connected for m in motors]), \
 ir = InfraredSensor(); assert ir.connected
 ts = TouchSensor();    assert ts.connected
 
-# Put the infrared sensor into proximity mode.
-ir.mode = 'IR-PROX'
-
 # We will need to check EV3 buttons state.
 btn = Button()
 
@@ -112,7 +109,7 @@ def turn():
 start()
 while not btn.any():
 
-    if ts.value():
+    if ts.is_pressed:
         # We bumped an obstacle.
         # Back away, turn and go in other direction.
         backup()
@@ -121,7 +118,7 @@ while not btn.any():
 
     # Infrared sensor in proximity mode will measure distance to the closest
     # object in front of it.
-    distance = ir.value()
+    distance = ir.proximity
 
     if distance > 60:
         # Path is clear, run at full speed.

--- a/demo/EXPLOR3R/remote-control.py
+++ b/demo/EXPLOR3R/remote-control.py
@@ -83,7 +83,7 @@ while not button.any():
     rc.process()
 
     # Backup when bumped an obstacle
-    if ts.value():
+    if ts.is_pressed:
         Sound.speak('Oops, excuse me!')
 
         for motor in (lmotor, rmotor):

--- a/demo/R3PTAR/r3ptar.py
+++ b/demo/R3PTAR/r3ptar.py
@@ -31,7 +31,7 @@ def hand_biter(done):
 
     while not done.is_set():
         # Wait until something (a hand?!) gets too close:
-        while s.proximity() > 30:
+        while s.proximity > 30:
             if done.is_set(): return
             time.sleep(0.1)
 

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -1630,19 +1630,21 @@ class TouchSensor(Sensor):
 
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         super(TouchSensor, self).__init__(address, name_pattern, name_exact, driver_name=['lego-ev3-touch', 'lego-nxt-touch'], **kwargs)
+        self.auto_mode = True
 
 
     # Button state
     MODE_TOUCH = 'TOUCH'
 
 
-    def is_pressed(self, set_mode=True):
+    @property
+    def is_pressed(self):
         """
         A boolean indicating whether the current touch sensor is being
         pressed.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_TOUCH
 
         return self.value(0)
@@ -1658,6 +1660,7 @@ class ColorSensor(Sensor):
 
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         super(ColorSensor, self).__init__(address, name_pattern, name_exact, driver_name=['lego-ev3-color'], **kwargs)
+        self.auto_mode = True
 
 
     # Reflected light. Red LED on.
@@ -1676,27 +1679,30 @@ class ColorSensor(Sensor):
     MODE_RGB_RAW = 'RGB-RAW'
 
 
-    def reflected_light_intensity(self, set_mode=True):
+    @property
+    def reflected_light_intensity(self):
         """
         Reflected light intensity as a percentage. Light on sensor is red.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_COL_REFLECT
 
         return self.value(0)
 
-    def ambient_light_intensity(self, set_mode=True):
+    @property
+    def ambient_light_intensity(self):
         """
         Ambient light intensity. Light on sensor is dimly lit blue.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_COL_AMBIENT
 
         return self.value(0)
 
-    def color(self, set_mode=True):
+    @property
+    def color(self):
         """
         Color detected by the sensor, categorized by overall value.
           - 0: No color
@@ -1709,47 +1715,51 @@ class ColorSensor(Sensor):
           - 7: Brown
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_COL_COLOR
 
         return self.value(0)
 
-    def raw(self, set_mode=True):
+    @property
+    def raw(self):
         """
         Red, green, and blue components of the detected color, in the range 0-1020.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_RGB_RAW
 
         return self.value(0), self.value(1), self.value(2)
 
-    def red(self, set_mode=True):
+    @property
+    def red(self):
         """
         Red component of the detected color, in the range 0-1020.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_RGB_RAW
 
         return self.value(0)
 
-    def green(self, set_mode=True):
+    @property
+    def green(self):
         """
         Green component of the detected color, in the range 0-1020.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_RGB_RAW
 
         return self.value(1)
 
-    def blue(self, set_mode=True):
+    @property
+    def blue(self):
         """
         Blue component of the detected color, in the range 0-1020.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_RGB_RAW
 
         return self.value(2)
@@ -1765,6 +1775,7 @@ class UltrasonicSensor(Sensor):
 
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         super(UltrasonicSensor, self).__init__(address, name_pattern, name_exact, driver_name=['lego-ev3-us', 'lego-nxt-us'], **kwargs)
+        self.auto_mode = True
 
 
     # Continuous measurement in centimeters.
@@ -1783,35 +1794,38 @@ class UltrasonicSensor(Sensor):
     MODE_US_SI_IN = 'US-SI-IN'
 
 
-    def distance_centimeters(self, set_mode=True):
+    @property
+    def distance_centimeters(self):
         """
         Measurement of the distance detected by the sensor,
         in centimeters.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_US_DIST_CM
 
         return self.value(0)
 
-    def distance_inches(self, set_mode=True):
+    @property
+    def distance_inches(self):
         """
         Measurement of the distance detected by the sensor,
         in inches.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_US_DIST_IN
 
         return self.value(0)
 
-    def other_sensor_present(self, set_mode=True):
+    @property
+    def other_sensor_present(self):
         """
         Value indicating whether another ultrasonic sensor could
         be heard nearby.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_US_LISTEN
 
         return self.value(0)
@@ -1827,6 +1841,7 @@ class GyroSensor(Sensor):
 
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         super(GyroSensor, self).__init__(address, name_pattern, name_exact, driver_name=['lego-ev3-gyro'], **kwargs)
+        self.auto_mode = True
 
 
     # Angle
@@ -1845,33 +1860,36 @@ class GyroSensor(Sensor):
     MODE_GYRO_CAL = 'GYRO-CAL'
 
 
-    def angle(self, set_mode=True):
+    @property
+    def angle(self):
         """
         The number of degrees that the sensor has been rotated
         since it was put into this mode.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_GYRO_ANG
 
         return self.value(0)
 
-    def rate(self, set_mode=True):
+    @property
+    def rate(self):
         """
         The rate at which the sensor is rotating, in degrees/second.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_GYRO_RATE
 
         return self.value(0)
 
-    def rate_and_angle(self, set_mode=True):
+    @property
+    def rate_and_angle(self):
         """
         Angle (degrees) and Rotational Speed (degrees/second).
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_GYRO_G_A
 
         return self.value(0), self.value(1)
@@ -1887,6 +1905,7 @@ class InfraredSensor(Sensor):
 
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         super(InfraredSensor, self).__init__(address, name_pattern, name_exact, driver_name=['lego-ev3-ir'], **kwargs)
+        self.auto_mode = True
 
 
     # Proximity
@@ -1905,13 +1924,14 @@ class InfraredSensor(Sensor):
     MODE_IR_CAL = 'IR-CAL'
 
 
-    def proximity(self, set_mode=True):
+    @property
+    def proximity(self):
         """
         A measurement of the distance between the sensor and the remote,
         as a percentage. 100% is approximately 70cm/27in.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_IR_PROX
 
         return self.value(0)
@@ -1927,6 +1947,7 @@ class SoundSensor(Sensor):
 
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         super(SoundSensor, self).__init__(address, name_pattern, name_exact, driver_name=['lego-nxt-sound'], **kwargs)
+        self.auto_mode = True
 
 
     # Sound pressure level. Flat weighting
@@ -1936,24 +1957,26 @@ class SoundSensor(Sensor):
     MODE_DBA = 'DBA'
 
 
-    def sound_pressure(self, set_mode=True):
+    @property
+    def sound_pressure(self):
         """
         A measurement of the measured sound pressure level, as a
         percent. Uses a flat weighting.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_DB
 
         return self.value(0)
 
-    def sound_pressure_low(self, set_mode=True):
+    @property
+    def sound_pressure_low(self):
         """
         A measurement of the measured sound pressure level, as a
         percent. Uses A-weighting, which focuses on levels up to 55 dB.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_DBA
 
         return self.value(0)
@@ -1969,6 +1992,7 @@ class LightSensor(Sensor):
 
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         super(LightSensor, self).__init__(address, name_pattern, name_exact, driver_name=['lego-nxt-light'], **kwargs)
+        self.auto_mode = True
 
 
     # Reflected light. LED on
@@ -1978,22 +2002,24 @@ class LightSensor(Sensor):
     MODE_AMBIENT = 'AMBIENT'
 
 
-    def reflected_light_intensity(self, set_mode=True):
+    @property
+    def reflected_light_intensity(self):
         """
         A measurement of the reflected light intensity, as a percentage.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_REFLECT
 
         return self.value(0)
 
-    def ambient_light_intensity(self, set_mode=True):
+    @property
+    def ambient_light_intensity(self):
         """
         A measurement of the ambient light intensity, as a percentage.
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_AMBIENT
 
         return self.value(0)

--- a/templates/special-sensors.liquid
+++ b/templates/special-sensors.liquid
@@ -37,6 +37,7 @@ endfor %}
 {% endif %}
     def __init__(self, address=None, name_pattern=SYSTEM_DEVICE_NAME_CONVENTION, name_exact=False, **kwargs):
         super({{ class_name }}, self).__init__(address, name_pattern, name_exact,{{ driver_name }} **kwargs)
+        self.auto_mode = True
 
 {% for prop in currentClass.propertyValues %}{%
   assign className = currentClass.friendlyName | downcase | underscore_spaces %}{%
@@ -51,7 +52,8 @@ endfor %}
 {% for mapping in currentClass.sensorValueMappings %}{%
   assign name = mapping.name | downcase | underscore_spaces %}{%
   assign mode = mapping.requiredMode | upcase | underscore_non_wc %}
-    def {{ name }}(self, set_mode=True):
+    @property
+    def {{ name }}(self):
         """{%
   for line in mapping.description %}{%
     if line %}
@@ -61,7 +63,7 @@ endfor %}
   endfor %}
         """
 
-        if set_mode:
+        if self.auto_mode:
             self.mode = self.MODE_{{ mode }}
 
         return {%


### PR DESCRIPTION
This converts special sensor methods to properties for the sake of uniformity throughout the library. See discussion in #228.

**This will break existing code!**

Instead of
```py
print( cs.ambient() )   # function call syntax
cs.mode = 'COL-AMBIENT'
while True:
    log(cs.ambient(do_set_mode=False)) # do not set mode when polling the sensor value
```
one has to
```py
print( cs.ambient )   # property syntax
cs.mode = 'COL-AMBIENT'
cs.auto_mode = False  # do not set mode when polling the sensor value
while True:
    log(cs.ambient)
```

I've updated my part of the demo scripts. @dwalton76, if we decide to merge this, could you take care of yours?