### PR TITLE
Make use of polling functionality in 16-ev3dev kernel

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -827,16 +827,17 @@ class Motor(Device):
             self._poll.register(self._state, select.POLLPRI)
 
         while True:
-            # wait for an event
-            for _ in self._poll.poll(None if timeout is None else timeout):
-                if timeout is not None and time.time() >= tic + timeout / 1000:
+            self._poll.poll(None if timeout is None else timeout)
+
+            if timeout is not None and time.time() >= tic + timeout / 1000:
+                return
+
+            if cond(self.state):
+                if hold_for is None:
                     return
-                if cond(self.state):
-                    if hold_for is None:
-                        return
-                    else:
-                        time.sleep(hold_for / 1000)
-                        if cond(self.state): return
+                else:
+                    time.sleep(hold_for / 1000)
+                    if cond(self.state): return
 
 
     def wait_until(self, s, hold_for=100, timeout=None):

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -810,7 +810,7 @@ class Motor(Device):
 
 # ~autogen
 
-    def wait(self, cond, hold_for=0.1, timeout=None):
+    def wait(self, cond, hold_for=100, timeout=None):
         """
         Blocks until ``cond(self.state)`` is ``True`` for at least ``hold_for``
         milliseconds.  The condition is checked when there is an I/O event
@@ -853,7 +853,7 @@ class Motor(Device):
         """
         self.wait(lambda state: s in state, hold_for, timeout)
 
-    def wait_while(self, s, hold_for=0.1, timeout=None):
+    def wait_while(self, s, hold_for=100, timeout=None):
         """
         Blocks until ``s`` is not in ``self.state`` for at least ``hold_for``
         milliseconds.  The condition is checked when there is an I/O event

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -816,6 +816,9 @@ class Motor(Device):
         milliseconds.  The condition is checked when there is an I/O event
         related to the ``state`` attribute.  Exits early when ``timeout`` (in
         milliseconds) is reached.
+
+        Returns ``True`` if the condition is met, and ``False`` if the timeout
+        is reached.
         """
 
         tic = time.time()
@@ -830,14 +833,14 @@ class Motor(Device):
             self._poll.poll(None if timeout is None else timeout)
 
             if timeout is not None and time.time() >= tic + timeout / 1000:
-                return
+                return False
 
             if cond(self.state):
                 if hold_for is None:
-                    return
+                    return True
                 else:
                     time.sleep(hold_for / 1000)
-                    if cond(self.state): return
+                    if cond(self.state): return True
 
 
     def wait_until(self, s, hold_for=100, timeout=None):
@@ -847,11 +850,14 @@ class Motor(Device):
         related to the ``state`` attribute.  Exits early when ``timeout`` (in
         milliseconds) is reached.
 
+        Returns ``True`` if the condition is met, and ``False`` if the timeout
+        is reached.
+
         Example::
 
             m.wait_until('stalled')
         """
-        self.wait(lambda state: s in state, hold_for, timeout)
+        return self.wait(lambda state: s in state, hold_for, timeout)
 
     def wait_while(self, s, hold_for=100, timeout=None):
         """
@@ -860,11 +866,14 @@ class Motor(Device):
         related to the ``state`` attribute.  Exits early when ``timeout`` (in
         milliseconds) is reached.
 
+        Returns ``True`` if the condition is met, and ``False`` if the timeout
+        is reached.
+
         Example::
 
             m.wait_while('running')
         """
-        self.wait(lambda state: s not in state, hold_for, timeout)
+        return self.wait(lambda state: s not in state, hold_for, timeout)
 
 def list_motors(name_pattern=Motor.SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
     """

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -813,9 +813,9 @@ class Motor(Device):
     def wait(self, cond, hold_for=0.1, timeout=None):
         """
         Blocks until ``cond(self.state)`` is ``True`` for at least ``hold_for``
-        seconds.  The condition is checked when there is an I/O event related
-        to the ``state`` attribute.  Exits early when ``timeout`` (in seconds)
-        is reached.
+        milliseconds.  The condition is checked when there is an I/O event
+        related to the ``state`` attribute.  Exits early when ``timeout`` (in
+        milliseconds) is reached.
         """
 
         tic = time.time()
@@ -828,23 +828,23 @@ class Motor(Device):
 
         while True:
             # wait for an event
-            for _ in self._poll.poll(None if timeout is None else timeout * 1000):
-                if timeout is not None and time.time() >= tic + timeout:
+            for _ in self._poll.poll(None if timeout is None else timeout):
+                if timeout is not None and time.time() >= tic + timeout / 1000:
                     return
                 if cond(self.state):
                     if hold_for is None:
                         return
                     else:
-                        time.sleep(hold_for)
+                        time.sleep(hold_for / 1000)
                         if cond(self.state): return
 
 
-    def wait_until(self, s, hold_for=0.1, timeout=None):
+    def wait_until(self, s, hold_for=100, timeout=None):
         """
         Blocks until ``s`` is in ``self.state`` for at least ``hold_for``
-        seconds.  The condition is checked when there is an I/O event related
-        to the ``state`` attribute.  Exits early when ``timeout`` (in seconds)
-        is reached.
+        milliseconds.  The condition is checked when there is an I/O event
+        related to the ``state`` attribute.  Exits early when ``timeout`` (in
+        milliseconds) is reached.
 
         Example::
 
@@ -855,9 +855,9 @@ class Motor(Device):
     def wait_while(self, s, hold_for=0.1, timeout=None):
         """
         Blocks until ``s`` is not in ``self.state`` for at least ``hold_for``
-        seconds.  The condition is checked when there is an I/O event related
-        to the ``state`` attribute.  Exits early when ``timeout`` (in seconds)
-        is reached.
+        milliseconds.  The condition is checked when there is an I/O event
+        related to the ``state`` attribute.  Exits early when ``timeout`` (in
+        milliseconds) is reached.
 
         Example::
 

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -810,12 +810,11 @@ class Motor(Device):
 
 # ~autogen
 
-    def wait(self, cond, hold_for=100, timeout=None):
+    def wait(self, cond, timeout=None):
         """
-        Blocks until ``cond(self.state)`` is ``True`` for at least ``hold_for``
-        milliseconds.  The condition is checked when there is an I/O event
-        related to the ``state`` attribute.  Exits early when ``timeout`` (in
-        milliseconds) is reached.
+        Blocks until ``cond(self.state)`` is ``True``.  The condition is
+        checked when there is an I/O event related to the ``state`` attribute.
+        Exits early when ``timeout`` (in milliseconds) is reached.
 
         Returns ``True`` if the condition is met, and ``False`` if the timeout
         is reached.
@@ -836,19 +835,14 @@ class Motor(Device):
                 return False
 
             if cond(self.state):
-                if hold_for is None:
-                    return True
-                else:
-                    time.sleep(hold_for / 1000)
-                    if cond(self.state): return True
+                return True
 
 
-    def wait_until(self, s, hold_for=100, timeout=None):
+    def wait_until(self, s, timeout=None):
         """
-        Blocks until ``s`` is in ``self.state`` for at least ``hold_for``
-        milliseconds.  The condition is checked when there is an I/O event
-        related to the ``state`` attribute.  Exits early when ``timeout`` (in
-        milliseconds) is reached.
+        Blocks until ``s`` is in ``self.state``.  The condition is checked when
+        there is an I/O event related to the ``state`` attribute.  Exits early
+        when ``timeout`` (in milliseconds) is reached.
 
         Returns ``True`` if the condition is met, and ``False`` if the timeout
         is reached.
@@ -857,14 +851,13 @@ class Motor(Device):
 
             m.wait_until('stalled')
         """
-        return self.wait(lambda state: s in state, hold_for, timeout)
+        return self.wait(lambda state: s in state, timeout)
 
-    def wait_while(self, s, hold_for=100, timeout=None):
+    def wait_while(self, s, timeout=None):
         """
-        Blocks until ``s`` is not in ``self.state`` for at least ``hold_for``
-        milliseconds.  The condition is checked when there is an I/O event
-        related to the ``state`` attribute.  Exits early when ``timeout`` (in
-        milliseconds) is reached.
+        Blocks until ``s`` is not in ``self.state``.  The condition is checked
+        when there is an I/O event related to the ``state`` attribute.  Exits
+        early when ``timeout`` (in milliseconds) is reached.
 
         Returns ``True`` if the condition is met, and ``False`` if the timeout
         is reached.
@@ -873,7 +866,7 @@ class Motor(Device):
 
             m.wait_while('running')
         """
-        return self.wait(lambda state: s not in state, hold_for, timeout)
+        return self.wait(lambda state: s not in state, timeout)
 
 def list_motors(name_pattern=Motor.SYSTEM_DEVICE_NAME_CONVENTION, **kwargs):
     """


### PR DESCRIPTION
Introduces the following functions:

* `Motor.wait(condition)`,
* `Motor.wait_while(state, timeout=None)`
* `Motor.wait_until(state, timeout=None)`

Make the following possible:

```py
m.wait_while('running')
m.wait_until('stalled')
```

Closes #230