### PR TITLE
Replace autogenerated properties for trigger, delay_on/off with custom ones

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -2211,12 +2211,12 @@ class Led(Device):
         # to 'timer', and destroyed when it is set to anything else.
         # This means the file cache may become outdated, and we may have to
         # reopen the file.
-        for i in range(2):
+        for retry in (True, False):
             try:
                 self._delay_on, value = self.get_attr_int(self._delay_on, 'delay_on')
                 return value
             except OSError:
-                if i == 0:
+                if retry:
                     self._delay_on = None
                 else:
                     raise
@@ -2228,12 +2228,12 @@ class Led(Device):
         # to 'timer', and destroyed when it is set to anything else.
         # This means the file cache may become outdated, and we may have to
         # reopen the file.
-        for i in range(2):
+        for retry in (True, False):
             try:
                 self._delay_on = self.set_attr_int(self._delay_on, 'delay_on', value)
                 return
             except OSError:
-                if i == 0:
+                if retry:
                     self._delay_on = None
                 else:
                     raise
@@ -2251,12 +2251,12 @@ class Led(Device):
         # to 'timer', and destroyed when it is set to anything else.
         # This means the file cache may become outdated, and we may have to
         # reopen the file.
-        for i in range(2):
+        for retry in (True, False):
             try:
                 self._delay_off, value = self.get_attr_int(self._delay_off, 'delay_off')
                 return value
             except OSError:
-                if i == 0:
+                if retry:
                     self._delay_off = None
                 else:
                     raise
@@ -2268,12 +2268,12 @@ class Led(Device):
         # to 'timer', and destroyed when it is set to anything else.
         # This means the file cache may become outdated, and we may have to
         # reopen the file.
-        for i in range(2):
+        for retry in (True, False):
             try:
                 self._delay_off = self.set_attr_int(self._delay_off, 'delay_off', value)
                 return
             except OSError:
-                if i == 0:
+                if retry:
                     self._delay_off = None
                 else:
                     raise

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -2146,6 +2146,8 @@ class Led(Device):
         self._triggers, value = self.get_attr_set(self._triggers, 'trigger')
         return value
 
+# ~autogen
+
     @property
     def trigger(self):
         """
@@ -2171,6 +2173,31 @@ class Led(Device):
     def trigger(self, value):
         self._trigger = self.set_attr_string(self._trigger, 'trigger', value)
 
+        # Workaround for ev3dev/ev3dev#225.
+        # When trigger is set to 'timer', we need to wait for 'delay_on' and
+        # 'delay_off' attributes to appear with correct permissions.
+        if value == 'timer':
+            for attr in ('delay_on', 'delay_off'):
+                path = self._path + '/' + attr
+
+                # Make sure the file has been created:
+                for _ in range(5):
+                    if os.path.exists(path):
+                        break
+                    time.sleep(0.2)
+                else:
+                    raise Exception('"{}" attribute has not been created'.format(attr))
+
+                # Make sure the file has correct permissions:
+                for _ in range(5):
+                    mode = stat.S_IMODE(os.stat(path)[stat.ST_MODE])
+                    if mode & stat.S_IRGRP and mode & stat.S_IWGRP:
+                        break
+                    time.sleep(0.2)
+                else:
+                    raise Exception('"{}" attribute has wrong permissions'.format(attr))
+
+
     @property
     def delay_on(self):
         """
@@ -2178,12 +2205,38 @@ class Led(Device):
         0 and the current brightness setting. The `on` time can
         be specified via `delay_on` attribute in milliseconds.
         """
-        self._delay_on, value = self.get_attr_int(self._delay_on, 'delay_on')
-        return value
+
+        # Workaround for ev3dev/ev3dev#225.
+        # 'delay_on' and 'delay_off' attributes are created when trigger is set
+        # to 'timer', and destroyed when it is set to anything else.
+        # This means the file cache may become outdated, and we may have to
+        # reopen the file.
+        for i in range(2):
+            try:
+                self._delay_on, value = self.get_attr_int(self._delay_on, 'delay_on')
+                return value
+            except OSError:
+                if i == 0:
+                    self._delay_on = None
+                else:
+                    raise
 
     @delay_on.setter
     def delay_on(self, value):
-        self._delay_on = self.set_attr_int(self._delay_on, 'delay_on', value)
+        # Workaround for ev3dev/ev3dev#225.
+        # 'delay_on' and 'delay_off' attributes are created when trigger is set
+        # to 'timer', and destroyed when it is set to anything else.
+        # This means the file cache may become outdated, and we may have to
+        # reopen the file.
+        for i in range(2):
+            try:
+                self._delay_on = self.set_attr_int(self._delay_on, 'delay_on', value)
+                return
+            except OSError:
+                if i == 0:
+                    self._delay_on = None
+                else:
+                    raise
 
     @property
     def delay_off(self):
@@ -2192,15 +2245,39 @@ class Led(Device):
         0 and the current brightness setting. The `off` time can
         be specified via `delay_off` attribute in milliseconds.
         """
-        self._delay_off, value = self.get_attr_int(self._delay_off, 'delay_off')
-        return value
+
+        # Workaround for ev3dev/ev3dev#225.
+        # 'delay_on' and 'delay_off' attributes are created when trigger is set
+        # to 'timer', and destroyed when it is set to anything else.
+        # This means the file cache may become outdated, and we may have to
+        # reopen the file.
+        for i in range(2):
+            try:
+                self._delay_off, value = self.get_attr_int(self._delay_off, 'delay_off')
+                return value
+            except OSError:
+                if i == 0:
+                    self._delay_off = None
+                else:
+                    raise
 
     @delay_off.setter
     def delay_off(self, value):
-        self._delay_off = self.set_attr_int(self._delay_off, 'delay_off', value)
+        # Workaround for ev3dev/ev3dev#225.
+        # 'delay_on' and 'delay_off' attributes are created when trigger is set
+        # to 'timer', and destroyed when it is set to anything else.
+        # This means the file cache may become outdated, and we may have to
+        # reopen the file.
+        for i in range(2):
+            try:
+                self._delay_off = self.set_attr_int(self._delay_off, 'delay_off', value)
+                return
+            except OSError:
+                if i == 0:
+                    self._delay_off = None
+                else:
+                    raise
 
-
-# ~autogen
 
     @property
     def brightness_pct(self):

--- a/templates/generic-get-set.liquid
+++ b/templates/generic-get-set.liquid
@@ -1,6 +1,7 @@
 {% assign class_name = currentClass.friendlyName | downcase | underscore_spaces %}{%
 for prop in currentClass.systemProperties %}{%
   assign prop_name = prop.name | downcase | underscore_spaces %}{%
+  if class_name != 'led' or prop_name != 'trigger' and prop_name != 'delay_on' and prop_name != 'delay_off' %}{%
   assign getter = prop.type %}{%
   assign setter = prop.type %}{%
   if prop.type == 'string array' %}{%
@@ -32,5 +33,6 @@ for prop in currentClass.systemProperties %}{%
         self._{{ prop_name }} = self.set_attr_{{ setter }}(self._{{ prop_name }}, '{{prop.systemName}}', value){%
 endif%}{% unless forloop.last %}
 {% endunless %}{%
+endif %}{%
 endfor %}
 


### PR DESCRIPTION
This introduces a workaround for ev3dev/ev3dev#225 and fixes #234.

* First, when `trigger` is set to `timer`, the setter blocks until `delay_on` and `delay_off` files have been created and got the correct attributes. The maximum wait time is 1 second.
* Second, since `delay_on` and `delay_off` attributes are created and destroyed depending on value of `trigger`, their cache entries may become outdated. This commit makes an attempt to reopen the files in this case.

One thing I am not fond of in this PR is that code for `delay_on`/`delay_off` getters and setters is mostly duplicated. We could move the functionality (try to reopen file once on OSError) into `Device._get_attribute` and `Device._set_attribute` to make it universal, but that would introduce slight inefficiency for all attribute getters and setters, when this is only required for leds. On the other hand, this would make our cache a bit more robust. @WasabiFan, @dwalton76, what do you think?