### PR TITLE
Provide Sound.set_volume(pct)

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -3054,7 +3054,7 @@ class Sound:
         """
         Sets the sound volume to the given percentage [0-100] by calling
         ``amixer -q set <channel> <pct>%``.
-        If channel is not specified, it tries to determine the default channel
+        If the channel is not specified, it tries to determine the default one
         by running ``amixer scontrols``. If that fails as well, it uses the
         ``Playback`` channel, as that is the only channel on the EV3.
         """

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -50,7 +50,7 @@ import select
 import time
 from os.path import abspath
 from struct import pack, unpack
-from subprocess import Popen
+from subprocess import Popen, check_output
 
 try:
     # This is a linux-specific module.
@@ -3050,7 +3050,20 @@ class Sound:
             return Popen(cmd_line, stdout=n, shell=True)
 
     @staticmethod
-    def set_volume(pct):
-        with open(os.devnull, 'w') as n:
-            cmd_line = '/usr/bin/amixer -q set Playback {0:d}%'.format(pct)
-            return Popen(cmd_line, stdout=n, shell=True)
+    def set_volume(pct, channel=None):
+        if channel is None:
+            # Get default channel as the first one that pops up in
+            # 'amixer scontrols' output, which contains strings in the
+            # following format:
+            #
+            #     Simple mixer control 'Master',0
+            #     Simple mixer control 'Capture',0
+            out = check_output(['amixer', 'scontrols']).decode()
+            m = re.search("'(?P<channel>[^']+)'", out)
+            if m:
+                channel = m.group('channel')
+            else:
+                channel = 'Playback'
+
+        cmd_line = '/usr/bin/amixer -q set {0} {1:d}%'.format(channel, pct)
+        Popen(cmd_line, shell=True).wait()

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -3051,6 +3051,13 @@ class Sound:
 
     @staticmethod
     def set_volume(pct, channel=None):
+        """
+        Sets the sound volume to the given percentage [0-100] by calling
+        ``amixer -q set <channel> <pct>%``.
+        If channel is not specified, it tries to determine the default channel
+        by running ``amixer scontrols``. If that fails as well, it uses the
+        ``Playback`` channel, as that is the only channel on the EV3.
+        """
         if channel is None:
             # Get default channel as the first one that pops up in
             # 'amixer scontrols' output, which contains strings in the

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -3048,3 +3048,9 @@ class Sound:
         with open(os.devnull, 'w') as n:
             cmd_line = '/usr/bin/espeak --stdout {0} "{1}" | /usr/bin/aplay -q'.format(espeak_opts, text)
             return Popen(cmd_line, stdout=n, shell=True)
+
+    @staticmethod
+    def set_volume(pct):
+        with open(os.devnull, 'w') as n:
+            cmd_line = '/usr/bin/amixer -q set Playback {0:d}%'.format(pct)
+            return Popen(cmd_line, stdout=n, shell=True)


### PR DESCRIPTION
See #258 

This uses a call to `amixer`, as opposed to using a sysfs attribute, since @dlech [hinted](https://github.com/rhempel/ev3dev-lang-python/issues/258#issuecomment-261574133) that could disappear in the future. Besides, every other method in the `Sound` class is a call to an executable, so why break the tradition?