### PR TITLE
Error on non-existing arguments/parameters

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -960,6 +960,12 @@ class LargeMotor(Motor):
 
 
 # ~autogen
+    __slots__ = [
+# ~autogen generic-class-slots classes.largeMotor>currentClass
+
+
+# ~autogen
+    ]
 # ~autogen generic-class classes.mediumMotor>currentClass
 
 class MediumMotor(Motor):
@@ -977,6 +983,12 @@ class MediumMotor(Motor):
 
 
 # ~autogen
+    __slots__ = [
+# ~autogen generic-class-slots classes.mediumMotor>currentClass
+
+
+# ~autogen
+    ]
 # ~autogen generic-class classes.actuonix50Motor>currentClass
 
 class ActuonixL1250Motor(Motor):
@@ -994,6 +1006,12 @@ class ActuonixL1250Motor(Motor):
 
 
 # ~autogen
+    __slots__ = [
+# ~autogen generic-class-slots classes.actuonix50Motor>currentClass
+
+
+# ~autogen
+    ]
 # ~autogen generic-class classes.actuonix100Motor>currentClass
 
 class ActuonixL12100Motor(Motor):
@@ -1011,6 +1029,12 @@ class ActuonixL12100Motor(Motor):
 
 
 # ~autogen
+    __slots__ = [
+# ~autogen generic-class-slots classes.actuonix100Motor>currentClass
+
+
+# ~autogen
+    ]
 # ~autogen generic-class classes.dcMotor>currentClass
 
 class DcMotor(Device):

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -1798,6 +1798,8 @@ class TouchSensor(Sensor):
     Touch Sensor
     """
 
+    __slots__ = ['auto_mode']
+
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
@@ -1827,6 +1829,8 @@ class ColorSensor(Sensor):
     """
     LEGO EV3 color sensor.
     """
+
+    __slots__ = ['auto_mode']
 
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
@@ -1943,6 +1947,8 @@ class UltrasonicSensor(Sensor):
     LEGO EV3 ultrasonic sensor.
     """
 
+    __slots__ = ['auto_mode']
+
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
@@ -2009,6 +2015,8 @@ class GyroSensor(Sensor):
     LEGO EV3 gyro sensor.
     """
 
+    __slots__ = ['auto_mode']
+
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
@@ -2073,6 +2081,8 @@ class InfraredSensor(Sensor):
     LEGO EV3 infrared sensor.
     """
 
+    __slots__ = ['auto_mode']
+
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
 
@@ -2114,6 +2124,8 @@ class SoundSensor(Sensor):
     """
     LEGO NXT Sound Sensor
     """
+
+    __slots__ = ['auto_mode']
 
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION
@@ -2159,6 +2171,8 @@ class LightSensor(Sensor):
     """
     LEGO NXT Light Sensor
     """
+
+    __slots__ = ['auto_mode']
 
     SYSTEM_CLASS_NAME = Sensor.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = Sensor.SYSTEM_DEVICE_NAME_CONVENTION

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -1580,6 +1580,7 @@ class Sensor(Device):
         self._value = [None,None,None,None,None,None,None,None]
 
         self._bin_data_format = None
+        self._bin_data_size = None
         self._bin_data = None
 
     __slots__ = [
@@ -1598,6 +1599,7 @@ class Sensor(Device):
 # ~autogen
     '_value',
     '_bin_data_format',
+    '_bin_data_size',
     '_bin_data',
     ]
 
@@ -1746,7 +1748,7 @@ class Sensor(Device):
             (28,)
         """
 
-        if '_bin_data_size' not in self.__dict__:
+        if self._bin_data_size == None:
             self._bin_data_size = {
                     "u8":     1,
                     "s8":     1,

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -108,6 +108,8 @@ def list_device_names(class_path, name_pattern, **kwargs):
 class Device(object):
     """The ev3dev device base class"""
 
+    __slots__ = ['_path', 'connected', '_device_index', 'kwargs']
+
     DEVICE_ROOT_PATH = '/sys/class'
 
     _DEVICE_INDEX = re.compile(r'^.*(?P<idx>\d+)$')
@@ -317,6 +319,41 @@ class Motor(Device):
 # ~autogen
 
         self._poll = None
+
+    __slots__ = [
+# ~autogen generic-class-slots classes.motor>currentClass
+
+    '_address',
+    '_command',
+    '_commands',
+    '_count_per_rot',
+    '_count_per_m',
+    '_driver_name',
+    '_duty_cycle',
+    '_duty_cycle_sp',
+    '_full_travel_count',
+    '_polarity',
+    '_position',
+    '_position_p',
+    '_position_i',
+    '_position_d',
+    '_position_sp',
+    '_max_speed',
+    '_speed',
+    '_speed_sp',
+    '_ramp_up_sp',
+    '_ramp_down_sp',
+    '_speed_p',
+    '_speed_i',
+    '_speed_d',
+    '_state',
+    '_stop_action',
+    '_stop_actions',
+    '_time_sp',
+
+# ~autogen
+    '_poll',
+    ]
 
 # ~autogen generic-get-set classes.motor>currentClass
 
@@ -1009,6 +1046,26 @@ class DcMotor(Device):
 
 # ~autogen
 
+    __slots__ = [
+# ~autogen generic-class-slots classes.dcMotor>currentClass
+
+    '_address',
+    '_command',
+    '_commands',
+    '_driver_name',
+    '_duty_cycle',
+    '_duty_cycle_sp',
+    '_polarity',
+    '_ramp_down_sp',
+    '_ramp_up_sp',
+    '_state',
+    '_stop_action',
+    '_stop_actions',
+    '_time_sp',
+
+# ~autogen
+    ]
+
 # ~autogen generic-get-set classes.dcMotor>currentClass
 
     @property
@@ -1263,6 +1320,23 @@ class ServoMotor(Device):
 
 # ~autogen
 
+    __slots__ = [
+# ~autogen generic-class-slots classes.servoMotor>currentClass
+
+    '_address',
+    '_command',
+    '_driver_name',
+    '_max_pulse_sp',
+    '_mid_pulse_sp',
+    '_min_pulse_sp',
+    '_polarity',
+    '_position_sp',
+    '_rate_sp',
+    '_state',
+
+# ~autogen
+    ]
+
 # ~autogen generic-get-set classes.servoMotor>currentClass
 
     @property
@@ -1483,6 +1557,25 @@ class Sensor(Device):
 
         self._bin_data_format = None
         self._bin_data = None
+
+    __slots__ = [
+# ~autogen generic-class-slots classes.sensor>currentClass
+
+    '_address',
+    '_command',
+    '_commands',
+    '_decimals',
+    '_driver_name',
+    '_mode',
+    '_modes',
+    '_num_values',
+    '_units',
+
+# ~autogen
+    '_value',
+    '_bin_data_format',
+    '_bin_data',
+    ]
 
 # ~autogen generic-get-set classes.sensor>currentClass
 
@@ -2134,6 +2227,20 @@ class Led(Device):
         self._delay_off = None
 
 # ~autogen
+
+    __slots__ = [
+# ~autogen generic-class-slots classes.led>currentClass
+
+    '_max_brightness',
+    '_brightness',
+    '_triggers',
+    '_trigger',
+    '_delay_on',
+    '_delay_off',
+
+# ~autogen
+    ]
+
 # ~autogen generic-get-set classes.led>currentClass
 
     @property
@@ -2163,6 +2270,8 @@ class Led(Device):
         """
         self._triggers, value = self.get_attr_set(self._triggers, 'trigger')
         return value
+
+
 
 # ~autogen
 
@@ -2526,6 +2635,20 @@ class PowerSupply(Device):
         self._type = None
 
 # ~autogen
+
+    __slots__ = [
+# ~autogen generic-class-slots classes.powerSupply>currentClass
+
+    '_measured_current',
+    '_measured_voltage',
+    '_max_voltage',
+    '_min_voltage',
+    '_technology',
+    '_type',
+
+# ~autogen
+    ]
+
 # ~autogen generic-get-set classes.powerSupply>currentClass
 
     @property
@@ -2639,6 +2762,20 @@ class LegoPort(Device):
         self._status = None
 
 # ~autogen
+
+    __slots__ = [
+# ~autogen generic-class-slots classes.legoPort>currentClass
+
+    '_address',
+    '_driver_name',
+    '_modes',
+    '_mode',
+    '_set_device',
+    '_status',
+
+# ~autogen
+    ]
+
 # ~autogen generic-get-set classes.legoPort>currentClass
 
     @property

--- a/templates/generic-class-slots.liquid
+++ b/templates/generic-class-slots.liquid
@@ -1,0 +1,4 @@
+{% for prop in currentClass.systemProperties %}{%
+   assign prop_name = prop.name | downcase | underscore_spaces %}
+    '_{{ prop_name }}',{%
+endfor %}

--- a/templates/special-sensors.liquid
+++ b/templates/special-sensors.liquid
@@ -28,6 +28,8 @@ for line in currentClass.description %}{%
 {%  endif %}{%
 endfor %}
     """
+
+    __slots__ = ['auto_mode']
 {% if currentClass.inheritance %}
     SYSTEM_CLASS_NAME = {{ base_class }}.SYSTEM_CLASS_NAME
     SYSTEM_DEVICE_NAME_CONVENTION = {{ base_class }}.SYSTEM_DEVICE_NAME_CONVENTION


### PR DESCRIPTION
This patch adds `__slots__` to all API classes that use `setattr` magic and `kwargs` for function parameters. Besides reducing memory and speeding up access, the main point of this change is that a typo when calling a function will result in an error, rather than silently setting non-existing properties.

```
In [1]: import ev3dev.ev3 as ev3
In [2]: m = ev3.MediumMotor()
In [3]: m.run_to_abs_pos(position_sp=72*20, speed_sd=500, stop_action='coast')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-08bcba75fb47> in <module>()
----> 1 m.run_to_abs_pos(position_sp=72*20, speed_sd=500, stop_action='coast')

/home/robot/ev3dev-lang-python/ev3dev/core.py in run_to_abs_pos(self, **kwargs)
    799         """
    800         for key in kwargs:
--> 801             setattr(self, key, kwargs[key])
    802         self.command = self.COMMAND_RUN_TO_ABS_POS
    803 

AttributeError: 'MediumMotor' object has no attribute 'speed_sd'
```
Currently the last line would just set the `speed_sd` property on the object, without doing anything, leaving it up to you to figure out why your motor went berserk or did nothing at all.

With the proposed change, you get instant feedback that you're doing something stupid.