### PR TITLE
Update template for special class

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -1898,6 +1898,27 @@ class ColorSensor(Sensor):
     # Raw Color Components. All LEDs rapidly cycling, appears white.
     MODE_RGB_RAW = 'RGB-RAW'
 
+    # Red color.
+    COLOR_BLACK = 1
+
+    # Blue color.
+    COLOR_BLUE = 2
+
+    # Green color.
+    COLOR_GREEN = 3
+
+    # Yellow color.
+    COLOR_YELLOW = 4
+
+    # Red color.
+    COLOR_RED = 5
+
+    # White color.
+    COLOR_WHITE = 6
+
+    # Brown color.
+    COLOR_BROWN = 7
+
 
     @property
     def reflected_light_intensity(self):

--- a/templates/special-sensors.liquid
+++ b/templates/special-sensors.liquid
@@ -47,8 +47,17 @@ endfor %}
   for value in prop.values %}{%
     for line in value.description %}
     # {{ line }}{%
-    endfor %}
-    {{ propName }}_{{ value.name | upcase | underscore_non_wc }} = '{{ value.name }}'
+    endfor %}{%
+    if value.value %}{%
+        if value.type == 'int' %}{%
+            capture val %}{{ value.value }}{% endcapture %}{%
+        else %}{%
+            capture val %}'{{ value.value }}'{% endcapture %}{%
+        endif %}{%
+    else %}{%
+        capture val %}'{{ value.name }}'{% endcapture %}{%
+    endif %}
+    {{ propName }}_{{ value.name | upcase | underscore_non_wc }} = {{ val }}
 {% endfor %}{%
 endfor %}
 {% for mapping in currentClass.sensorValueMappings %}{%


### PR DESCRIPTION
Use property value/type when available. In this particular case, this adds color constants to the color sensor class. Based on ev3dev/ev3dev-lang#177.

Fixes #296.