### PR TITLE
Sphinx py3

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = ./sphinx3-build
 PAPER         =
 BUILDDIR      = _build
 

--- a/docs/sphinx3-build
+++ b/docs/sphinx3-build
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+"""
+Same as /usr/bin/sphinx-build but with different
+interpreter
+
+Source: http://stackoverflow.com/a/24675806
+"""
+
+import sys
+
+if __name__ == '__main__':
+    from sphinx import main, make_main
+    if sys.argv[1:2] == ['-M']:
+        sys.exit(make_main(sys.argv))
+    else:
+        sys.exit(main(sys.argv))
+


### PR DESCRIPTION
workaround for building the Sphinx doc on environments with Python2 as default interpreter