### PR TITLE
Add tuple of all colors to ColorSensor

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -1939,6 +1939,17 @@ class ColorSensor(Sensor):
     #: Brown color.
     COLOR_BROWN = 7
 
+    #: Tuple of all colors
+    COLORS = (
+        'nocolor',
+        'black',
+        'blue',
+        'green',
+        'yellow',
+        'red',
+        'white',
+        'brown',
+    )
 
     @property
     def reflected_light_intensity(self):


### PR DESCRIPTION
This adds a tuple mapping the color ints to human readable strings.

Could be used like this:

```python
from ev3dev.ev3 import ColorSensor

c = ColorSensor('1')
print(c.COLORS[c.color])
```