### PR TITLE
Added wait_until_not_moving()

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -910,6 +910,19 @@ class Motor(Device):
                 return True
 
     def wait_until_not_moving(self, timeout=None):
+        """
+        Blocks until ``running`` is not in ``self.state`` or ``stalled`` is in
+        ``self.state``.  The condition is checked when there is an I/O event
+        related to the ``state`` attribute.  Exits early when ``timeout``
+        (in milliseconds) is reached.
+
+        Returns ``True`` if the condition is met, and ``False`` if the timeout
+        is reached.
+
+        Example::
+
+            m.wait_until_not_moving()
+        """
         return self.wait(lambda state: self.STATE_RUNNING not in state or self.STATE_STALLED in state, timeout)
 
     def wait_until(self, s, timeout=None):

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -909,6 +909,8 @@ class Motor(Device):
             if cond(self.state):
                 return True
 
+    def wait_until_not_moving(self, timeout=None):
+        return self.wait(lambda state: self.STATE_RUNNING not in state or self.STATE_STALLED in state, timeout)
 
     def wait_until(self, s, timeout=None):
         """


### PR DESCRIPTION
If you call `wait_while('running', timeout=1000)` there are times when the state reads both `running` and `stalled` so you end up waiting for your timeout to expire even though the motor has stalled.  The added function allows you to wait until the motor has stopped, either due to a stall or because it is no longer 'running'.

This helps my rubiks cube robot run a good bit faster as I don't end up waiting on so many timeouts in the wait_while calls.