### PR TITLE
Add v1.0.0 release to changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,27 @@
-python-ev3dev (0.8.1) stable; urgency=medium
+python-ev3dev (1.0.0) stable; urgency=medium
+
+  [Denis Demidov]
+  * Add constants for color values to color sensor class
+  * Update documentation on motors
+  * Add getters to check state of motors
+  * Implement BeaconSeeker class
+  * Fix scaling of floating-point values from sensors
+
+  [Eric Pascual]
+  * Add Sound.play_song method
+
+  [Stefan Sauer]
+  * Make sound commands cancelable
+
+  [Maximilian Nöthe]
+  * Add tuples for sensor modes
+
+  [Daniel Walton]
+  * Add wait_until_not_moving for motors
+
+ -- TODO
+
+ python-ev3dev (0.8.1) stable; urgency=medium
 
   [Kaelin Laundry]
   * Documentation updates


### PR DESCRIPTION
I think it's time that we tag a v1.0.0 release. As noted in #339, we have some breaking changes to make for ev3dev-stretch; that seems to be a good occasion to release a major version of the library for ev3dev-jessie and then reconfigure branches and change modes to work on Stretch.

The branch-relative comparison can be found [here](https://github.com/rhempel/ev3dev-lang-python/compare/master...develop), or you can look [here](https://github.com/rhempel/ev3dev-lang-python/compare/83abb6c...0036637) for a future-proof static comparison. In the changelog I omitted some README and demo changes; I can't recall if those demos are included in the package or not, but I can add those entries if needed.

We have a few features open right now that we might want to land before this release; specifically, #336 and the work for #331 [here](https://github.com/rhempel/ev3dev-lang-python/tree/throw-friendly-errors).