### PR TITLE
Throw friendly errors

### DIFF
--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -49,6 +49,7 @@ import select
 import shlex
 import stat
 import time
+import errno
 from os.path import abspath
 from struct import pack, unpack
 from subprocess import Popen, check_output, PIPE
@@ -209,12 +210,12 @@ class Device(object):
                 attribute.write(value.encode())
                 attribute.flush()
             except Exception as ex:
-                _raise_friendly_access_error(ex, name)
+                self._raise_friendly_access_error(ex, name)
             return attribute
         else:
             raise Exception('Device is not connected')
 
-    def _raise_friendly_access_error(driver_error, attribute):
+    def _raise_friendly_access_error(self, driver_error, attribute):
         if not isinstance(driver_error, OSError):
             raise driver_error
 
@@ -223,10 +224,10 @@ class Device(object):
                 try:
                     max_speed = self.max_speed
                 except (AttributeError, Exception):
-                    raise ValueError("The given speed value was out of range")
+                    raise ValueError("The given speed value was out of range") from driver_error
                 else:
-                    raise ValueError("The given speed value was out of range. Max speed: " + str(max_speed))
-            raise ValueError("One or more arguments were out of range or invalid")
+                    raise ValueError("The given speed value was out of range. Max speed: +/-" + str(max_speed)) from driver_error
+            raise ValueError("One or more arguments were out of range or invalid") from driver_error
         raise driver_error
 
     def get_attr_int(self, attribute, name):

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -223,10 +223,10 @@ class Device(object):
                 try:
                     max_speed = self.max_speed
                 except (AttributeError, Exception):
-                    raise Exception("The given speed value was out of range")
+                    raise ValueError("The given speed value was out of range")
                 else:
-                    raise Exception("The given speed value was out of range. Max speed: " + str(max_speed))
-            raise Exception("One or more arguments were out of range or invalid")
+                    raise ValueError("The given speed value was out of range. Max speed: " + str(max_speed))
+            raise ValueError("One or more arguments were out of range or invalid")
         raise driver_error
 
     def get_attr_int(self, attribute, name):

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -204,11 +204,30 @@ class Device(object):
                 attribute = self._attribute_file_open( name )
             else:
                 attribute.seek(0)
-            attribute.write(value.encode())
-            attribute.flush()
+
+            try:
+                attribute.write(value.encode())
+                attribute.flush()
+            except Exception as ex:
+                _raise_friendly_access_error(ex, name)
             return attribute
         else:
             raise Exception('Device is not connected')
+
+    def _raise_friendly_access_error(driver_error, attribute):
+        if not isinstance(driver_error, OSError):
+            raise driver_error
+
+        if driver_error.errno == errno.EINVAL:
+            if attribute == "speed_sp":
+                try:
+                    max_speed = self.max_speed
+                except AttributeError, Exception:
+                    raise Exception("The given speed value was out of range")
+                else:
+                    raise Exception("The given speed value was out of range. Max speed: " + str(max_speed))
+            raise Exception("One or more arguments were out of range or invalid")
+        raise driver_error
 
     def get_attr_int(self, attribute, name):
         attribute, value = self._get_attribute(attribute, name)

--- a/ev3dev/core.py
+++ b/ev3dev/core.py
@@ -222,7 +222,7 @@ class Device(object):
             if attribute == "speed_sp":
                 try:
                     max_speed = self.max_speed
-                except AttributeError, Exception:
+                except (AttributeError, Exception):
                     raise Exception("The given speed value was out of range")
                 else:
                     raise Exception("The given speed value was out of range. Max speed: " + str(max_speed))


### PR DESCRIPTION
Fixes #331 

It would be nice if we were able to adapt the message when you attempt to run for distance with a negative sign, but commands are read-only and I didn't see an easy way to pipe that through. Any suggestions for other properties?

```
robot@ev3dev:~$ python3
Python 3.5.3 (default, Jan 19 2017, 14:11:04)
[GCC 6.3.0 20170118] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ev3dev.ev3 as ev3
>>> m = ev3.Motor()
>>> m.connected
True
>>> m.speed_sp = -100000
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 210, in _set_attribute
    attribute.write(value.encode())
OSError: [Errno 22] Invalid argument

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 604, in speed_sp
    self._speed_sp = self.set_attr_int(self._speed_sp, 'speed_sp', value)
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 238, in set_attr_int
    return self._set_attribute(attribute, name, str(int(value)))
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 213, in _set_attribute
    self._raise_friendly_access_error(ex, name)
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 229, in _raise_friendly_access_error
    raise ValueError("The given speed value was out of range. Max speed: +/-" + str(max_speed)) from driver_error
ValueError: The given speed value was out of range. Max speed: +/-1050
>>> m.speed_sp = 1000000
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 210, in _set_attribute
    attribute.write(value.encode())
OSError: [Errno 22] Invalid argument

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 604, in speed_sp
    self._speed_sp = self.set_attr_int(self._speed_sp, 'speed_sp', value)
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 238, in set_attr_int
    return self._set_attribute(attribute, name, str(int(value)))
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 213, in _set_attribute
    self._raise_friendly_access_error(ex, name)
  File "/usr/lib/python3/dist-packages/ev3dev/core.py", line 229, in _raise_friendly_access_error
    raise ValueError("The given speed value was out of range. Max speed: +/-" + str(max_speed)) from driver_error
ValueError: The given speed value was out of range. Max speed: +/-1050
```